### PR TITLE
fix boot.sh to start nodejs app

### DIFF
--- a/boot.sh
+++ b/boot.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-cd /home/shippable/micro/nod/$COMPONENT
+cd /home/shippable/reqProc
 mkdir -p logs
 
 if [ "$RUN_MODE" == "dev" ]; then


### PR DESCRIPTION
https://github.com/Shippable/reqProc/issues/5

This makes the node.js app to startup