### PR TITLE
corrects the path of shippable adapter

### DIFF
--- a/_common/jobConsoleAdapter.js
+++ b/_common/jobConsoleAdapter.js
@@ -4,7 +4,7 @@ var self = Adapter;
 module.exports = self;
 
 var uuid = require('node-uuid');
-var ShippableAdapter = require('../../_global/shippable/Adapter.js');
+var ShippableAdapter = require('./shippable/Adapter.js');
 
 function Adapter(apiToken, jobId, consoleBatchSize, consoleBufferTimeInMS) {
   this.who = util.format('%s|micro|_common|jobConsoleAdapter|jobId:%s',

--- a/_common/micro/MicroService.js
+++ b/_common/micro/MicroService.js
@@ -4,7 +4,7 @@ var self = MicroService;
 module.exports = self;
 
 var amqp = require('amqp');
-var ShippableAdapter = require('../../../_global/shippable/Adapter.js');
+var ShippableAdapter = require('../shippable/Adapter.js');
 
 function MicroService(params) {
   logger.info('Starting', msName);

--- a/_common/micro/healthChecks/checkShippableApi.js
+++ b/_common/micro/healthChecks/checkShippableApi.js
@@ -2,7 +2,7 @@
 var self = checkShippableApi;
 module.exports = self;
 
-var Adapter = require('../../../../_global/shippable/Adapter.js');
+var Adapter = require('../../shippable/Adapter.js');
 
 function checkShippableApi(params, callback) {
   var bag = {

--- a/_common/micro/healthChecks/postNodeStats.js
+++ b/_common/micro/healthChecks/postNodeStats.js
@@ -3,7 +3,7 @@ var self = postNodeStats;
 module.exports = self;
 
 var exec = require('child_process').exec;
-var ShippableAdapter = require('../../../../_global/shippable/Adapter.js');
+var ShippableAdapter = require('../../shippable/Adapter.js');
 var STATS_PERIOD = 2 * 60 * 1000; // 2 minutes
 var os = require('os');
 var diskUsage = require('diskusage');

--- a/_common/micro/healthChecks/updateNodeStatus.js
+++ b/_common/micro/healthChecks/updateNodeStatus.js
@@ -2,7 +2,7 @@
 var self = updateNodeStatus;
 module.exports = self;
 
-var ShippableAdapter = require('../../../../_global/shippable/Adapter.js');
+var ShippableAdapter = require('../../shippable/Adapter.js');
 var statusCodes = require('../../../../_global/statusCodes.js');
 
 function updateNodeStatus(params, callback) {

--- a/_common/micro/healthChecks/validateNode.js
+++ b/_common/micro/healthChecks/validateNode.js
@@ -3,7 +3,7 @@ var self = validateNode;
 module.exports = self;
 
 var exec = require('child_process').exec;
-var ShippableAdapter = require('../../../../_global/shippable/Adapter.js');
+var ShippableAdapter = require('../../shippable/Adapter.js');
 var VALIDATION_PERIOD = 2 * 60 * 1000; // 2 minutes
 
 function validateNode(params, callback) {

--- a/_common/micro/healthChecks/validateService.js
+++ b/_common/micro/healthChecks/validateService.js
@@ -2,7 +2,7 @@
 var self = validateService;
 module.exports = self;
 
-var ShippableAdapter = require('../../../../_global/shippable/Adapter.js');
+var ShippableAdapter = require('../../shippable/Adapter.js');
 var VALIDATION_PERIOD = 2 * 60 * 1000; // 2 minutes
 
 function validateService(params, callback) {

--- a/microWorker.js
+++ b/microWorker.js
@@ -3,7 +3,7 @@
 var self = microWorker;
 module.exports = self;
 
-var Adapter = require('../_global/shippable/Adapter.js');
+var Adapter = require('./_common/shippable/Adapter.js');
 var exec = require('child_process').exec;
 
 var pathPlaceholder = '{{TYPE}}';


### PR DESCRIPTION
https://github.com/Shippable/reqProc/issues/6

We don't have `_global` anymore and the files needed from `_global` are moved to `_common` 

This PR updates all the references to the shippable adapter file which was in `_global` in case of `genExec`, but now moved to `_common` 