### PR TITLE
fix buildConsoleAdapter path in microworker

### DIFF
--- a/microWorker.js
+++ b/microWorker.js
@@ -9,7 +9,7 @@ var exec = require('child_process').exec;
 var pathPlaceholder = '{{TYPE}}';
 var workflowPath = './workflows/' + pathPlaceholder + '.js';
 var JobConsoleAdapter = require('./_common/jobConsoleAdapter.js');
-var BuildJobConsoleAdapter = require('../_global/buildJobConsoleAdapter.js');
+var BuildJobConsoleAdapter = require('./_common/buildJobConsoleAdapter.js');
 
 function microWorker(message, callback) {
   var bag = {


### PR DESCRIPTION
https://github.com/Shippable/reqProc/issues/8

[buildJobConsoleAdapter.js](https://github.com/Shippable/reqProc/blob/master/_common/buildJobConsoleAdapter.js) was already moved from `_global` to `_common`. So updated it's reference.
