### PR TITLE
checks for emptiness of dir envs

### DIFF
--- a/_common/micro/setupMS.js
+++ b/_common/micro/setupMS.js
@@ -24,6 +24,12 @@ function setupMS(params) {
   global.config.subscriptionId = process.env.SUBSCRIPTION_ID;
   global.config.apiToken = process.env.SHIPPABLE_API_TOKEN;
   global.config.execImage = process.env.EXEC_IMAGE;
+  global.config.baseDir = process.env.BASE_DIR;
+  global.config.reqProcDir = process.env.REQPROC_DIR;
+  global.config.reqExecDir = process.env.REQEXEC_DIR;
+  global.config.reqExecSrcDir = process.env.REQEXEC_SRC_DIR;
+  global.config.reqKickDir = process.env.REQKICK_DIR;
+  global.config.buildDir = process.env.BUILD_DIR;
   /* Node Type Codes */
   global.nodeTypeCodes = {
     dynamic: 7000,

--- a/app.js
+++ b/app.js
@@ -31,6 +31,24 @@ if (!global.config.inputQueue)
 if (!global.config.apiUrl)
   consoleErrors.push(util.format('%s is missing: apiUrl', who));
 
+if (!global.config.baseDir)
+  consoleErrors.push(util.format('%s is missing: baseDir', who));
+
+if (!global.config.reqProcDir)
+  consoleErrors.push(util.format('%s is missing: reqProcDir', who));
+
+if (!global.config.reqExecDir)
+  consoleErrors.push(util.format('%s is missing: reqExecDir', who));
+
+if (!global.config.reqExecSrcDir)
+  consoleErrors.push(util.format('%s is missing: reqExecSrcDir', who));
+
+if (!global.config.reqKickDir)
+  consoleErrors.push(util.format('%s is missing: reqKickDir', who));
+
+if (!global.config.buildDir)
+  consoleErrors.push(util.format('%s is missing: buildDir', who));
+
 if (consoleErrors.length > 0) {
   _.each(consoleErrors,
     function (err) {


### PR DESCRIPTION
https://github.com/Shippable/reqProc/issues/36

When required ENVs are not found, the following logs appear in reqProc
![image](https://user-images.githubusercontent.com/4211715/31985049-508ad468-b981-11e7-9c30-0e68c46b6707.png)

If all the envs are non-empty, the reqProc is initialized successfully 
![image](https://user-images.githubusercontent.com/4211715/31985712-a32be0f2-b983-11e7-9c02-42d12a059d8a.png)
