### PR TITLE
moves legacy ci to ci workflow

### DIFF
--- a/_common/executeJobScript.js
+++ b/_common/executeJobScript.js
@@ -1,0 +1,334 @@
+'use strict';
+var self = executeJobScript;
+module.exports = self;
+
+var spawn = require('child_process').spawn;
+var fs = require('fs-extra');
+var path = require('path');
+
+function executeJobScript(externalBag, callback) {
+  var bag = {
+    consoleAdapter: externalBag.consoleAdapter,
+    builderApiAdapter: externalBag.builderApiAdapter,
+    steps: externalBag.steps,
+    mexecFileNameWithPath: externalBag.mexecFileNameWithPath,
+    isFailedJob: false,
+    continueNextStep: true,
+    ciJob: externalBag.ciJob,
+    jobEnvDir: externalBag.jobEnvDir,
+    readOnStartJobEnvs: false,
+    putOnStartJobEnvs: false,
+    onStartJobEnvs: [],
+    rawMessage: externalBag.rawMessage,
+    cexecMessageNameWithLocation: externalBag.cexecMessageNameWithLocation,
+    sshDir: externalBag.sshDir,
+    tmpFile: '/tmp/mexec/tmp-script.sh',
+    sshAddFragment: ''
+  };
+
+  bag.who = msName + '|_common|' + self.name;
+  logger.verbose(bag.who, 'Starting');
+
+  async.series([
+      _checkInputParams.bind(null, bag),
+      _executeSteps.bind(null, bag)
+    ],
+    function () {
+      logger.verbose(bag.who, 'Completed');
+      //Force pushing all the debug messages
+      bag.consoleAdapter.publishDebugMessages();
+      return callback(bag.isFailedJob);
+    }
+  );
+}
+
+function _checkInputParams(bag, next) {
+  var who = bag.who + '|' + _checkInputParams.name;
+  logger.verbose(who, 'Inside');
+
+  return next();
+}
+
+function _executeSteps(bag, next) {
+  var who = bag.who + '|' + _executeSteps.name;
+  logger.verbose(who, 'Inside');
+
+  async.eachOfSeries(bag.steps,
+    function (step, index, nextStep) {
+      bag.currentStep = step;
+      bag.currentStepIndex = index;
+      async.series([
+          __writeCexecStepsToFile.bind(null, bag),
+          __writeStepToFile.bind(null, bag),
+          __readSSHKeys.bind(null, bag),
+          __generateExecScript.bind(null, bag),
+          __executeTask.bind(null, bag),
+          __readOnStartEnvs.bind(null, bag),
+          __putOnStartEnvsInJob.bind(null, bag)
+        ],
+        function (err) {
+          return nextStep(err);
+        }
+      );
+    },
+    function (err) {
+      return next(err);
+    }
+  );
+}
+
+function __writeCexecStepsToFile(bag, done) {
+  bag.consoleAdapter.setCurrentScriptType(bag.currentStep.scriptType);
+
+  if (!bag.continueNextStep) return done();
+  if (bag.currentStep.who !== 'mexec') return done();
+  if (bag.currentStepIndex + 1 === bag.steps.length) return done();
+  if (bag.steps[bag.currentStepIndex + 1].who !== 'cexec') return done();
+
+  var who = bag.who + '|' + __writeCexecStepsToFile.name;
+  logger.debug(who, 'Inside');
+
+  var messageClone = _.clone(bag.rawMessage);
+
+  messageClone.steps =
+    messageClone.steps.splice(bag.currentStepIndex + 1, bag.steps.length);
+
+  fs.writeFile(bag.cexecMessageNameWithLocation, JSON.stringify(messageClone),
+    function (err) {
+      if (err) {
+        var msg = util.format('%s, Failed with err:%s', who, err);
+        bag.consoleAdapter.publishMsg(msg);
+        return done(err);
+      }
+      fs.chmodSync(bag.cexecMessageNameWithLocation, '755');
+      return done();
+    }
+  );
+}
+
+function __writeStepToFile(bag, done) {
+  if (!bag.continueNextStep) return done();
+  if (bag.currentStep.who !== 'mexec') return done();
+
+  var who = bag.who + '|' + __writeStepToFile.name;
+  logger.debug(who, 'Inside');
+
+  fs.writeFile(bag.tmpFile,
+    bag.currentStep.script,
+    function (err) {
+      if (err) {
+        var msg = util.format('%s, Failed with err:%s', who, err);
+        bag.consoleAdapter.publishMsg(msg);
+        return done(err);
+      }
+      fs.chmodSync(bag.tmpFile, '755');
+      return done();
+    }
+  );
+}
+
+function __readSSHKeys(bag, done) {
+  if (!bag.continueNextStep) return done();
+  if (bag.currentStep.who !== 'mexec') return done();
+
+  var who = bag.who + '|' + __readSSHKeys.name;
+  logger.debug(who, 'Inside');
+
+  fs.readdir(bag.sshDir,
+    function (err, fileNames) {
+      if (err) {
+        var msg = util.format('%s, Failed with err:%s', who, err);
+        bag.consoleAdapter.publishMsg(msg);
+        return done(err);
+      }
+      var fileNameWithLocation = _.map(fileNames,
+        function (fileName) {
+          return path.join(bag.sshDir, fileName);
+        }
+      );
+
+      fileNameWithLocation = fileNameWithLocation.sort();
+      bag.sshAddFragment = '';
+
+      _.each(fileNameWithLocation,
+        function (fileName) {
+          bag.sshAddFragment = bag.sshAddFragment + 'ssh-add ' + fileName + ';';
+        }
+      );
+
+      return done();
+    }
+  );
+}
+
+function __generateExecScript(bag, done) {
+  if (!bag.continueNextStep) return done();
+  if (bag.currentStep.who !== 'mexec') return done();
+
+  var who = bag.who + '|' + __generateExecScript.name;
+  logger.debug(who, 'Inside');
+
+  var scriptContent =
+    util.format('ssh-agent /bin/bash -c \'%s %s \'',
+      bag.sshAddFragment, bag.tmpFile);
+
+  fs.outputFile(bag.mexecFileNameWithPath, scriptContent,
+    function (err) {
+      if (err) {
+        var msg = util.format('%s, Failed with err:%s', who, err);
+        bag.consoleAdapter.publishMsg(msg);
+        return done(err);
+      }
+      fs.chmodSync(bag.mexecFileNameWithPath, '755');
+      return done();
+    }
+  );
+}
+
+function __executeTask(bag, done) {
+  if (!bag.continueNextStep) return done();
+  if (bag.currentStep.who !== 'mexec') return done();
+
+  var who = bag.who + '|' + __executeTask.name;
+  logger.debug(who, 'Inside');
+
+  var exec = spawn('/bin/bash', ['-c', bag.mexecFileNameWithPath + ' 2>&1'],
+    {});
+  exec.stdout.on('data',
+    function (data)  {
+      _.each(data.toString().split('\n'),
+        function (consoleLine) {
+          if (!_.isEmpty(consoleLine))
+            __parseLogLine(bag, consoleLine);
+        }
+      );
+    }
+  );
+
+  exec.on('close',
+    function (exitCode)  {
+      if (exitCode) {
+        bag.isFailedJob = true;
+        bag.continueNextStep = false;
+      }
+      return done();
+    }
+  );
+}
+
+function __readOnStartEnvs(bag, done) {
+  if (!bag.continueNextStep) return done();
+  if (bag.currentStep.who !== 'mexec') return done();
+  if (!bag.readOnStartJobEnvs) return done();
+
+  var who = bag.who + '|' + __readOnStartEnvs.name;
+  logger.debug(who, 'Inside');
+
+  if (!fs.existsSync(bag.jobEnvDir)) {
+    bag.readOnStartJobEnvs = false;
+    return done();
+  }
+
+  bag.putOnStartJobEnvs = true;
+  var fileNames = fs.readdirSync(bag.jobEnvDir);
+  if (_.isEmpty(fileNames)) {
+    bag.readOnStartJobEnvs = false;
+    return done();
+  }
+
+  var validJSONFiles = [];
+
+  _.each(fileNames,
+    function (fileName) {
+      if (path.extname(fileName) === '.json')
+        validJSONFiles.push(path.join(bag.jobEnvDir, fileName));
+    }
+  );
+
+  if (_.isEmpty(validJSONFiles)) {
+    bag.readOnStartJobEnvs = false;
+    return done();
+  }
+
+  _.each(validJSONFiles,
+    function (fileName) {
+      var json = fs.readFileSync(fileName, 'utf8');
+      var parsedJSON = __parseBody(json);
+      bag.onStartJobEnvs.push(parsedJSON);
+    }
+  );
+  bag.readOnStartJobEnvs = false;
+  return done();
+}
+
+function __putOnStartEnvsInJob(bag, done) {
+  if (!bag.continueNextStep) return done();
+  if (bag.currentStep.who !== 'mexec') return done();
+  if (!bag.putOnStartJobEnvs) return done();
+
+  var who = bag.who + '|' + __putOnStartEnvsInJob.name;
+  logger.debug(who, 'Inside');
+
+  bag.ciJob.onStartJobEnvs = bag.onStartJobEnvs;
+
+  bag.builderApiAdapter.putJobById(bag.ciJob.id, bag.ciJob,
+    function (err, job) {
+      if (err) {
+        var msg = util.format('%s, Failed to save onStartJobEnvs ' +
+          'for job:%s with error:%s', who, bag.ciJob.id, err);
+        bag.consoleAdapter.publishMsg(msg);
+      }
+      bag.ciJob = job;
+      bag.putOnStartJobEnvs = false;
+      return done();
+    }
+  );
+}
+
+function __parseLogLine(bag, line) {
+  var lineSplit = line.split('|');
+
+  var cmdJSON = null;
+  var grpJSON = null;
+  var isSuccess = null;
+  var messagesNotToBePosted = ['__SH__SHOULD_CONTINUE__',
+    '__SH__SCRIPT_END_SUCCESS__'];
+
+  if (lineSplit[0] === '__SH__GROUP__START__') {
+    grpJSON = JSON.parse(lineSplit[1]);
+    bag.consoleAdapter.openGrp(lineSplit[2], grpJSON.is_shown);
+  } else if (lineSplit[0] === '__SH__GROUP__END__') {
+    grpJSON = JSON.parse(lineSplit[1]);
+    isSuccess = grpJSON.exitcode === '0';
+    bag.consoleAdapter.closeGrp(isSuccess, grpJSON.is_shown);
+  } else if (lineSplit[0] === '__SH__CMD__START__') {
+    bag.consoleAdapter.openCmd(lineSplit[2]);
+  } else if (lineSplit[0] === '__SH__CMD__END__') {
+    cmdJSON = JSON.parse(lineSplit[1]);
+    isSuccess = cmdJSON.exitcode === '0';
+    bag.consoleAdapter.closeCmd(isSuccess);
+  } else if (lineSplit[0] === '__SH__SCRIPT_END_FAILURE__') {
+    bag.isFailedJob = true;
+  } else if (lineSplit[0] === '__SH__SHOULD_NOT_CONTINUE__') {
+    bag.continueNextStep = false;
+    bag.isFailedJob = true;
+  } else if (lineSplit[0] === '__SH_ON_START_JOB_ENV_SCRIPT_COMPLETE__') {
+    bag.readOnStartJobEnvs = true;
+  } else if (!_.contains(messagesNotToBePosted, lineSplit[0])) {
+    bag.consoleAdapter.publishMsg(line);
+  }
+}
+
+function __parseBody(body) {
+  var parsedBody = {};
+  if (typeof body === 'object') {
+    parsedBody = body;
+  } else {
+    try {
+      parsedBody = JSON.parse(body);
+    } catch (e) {
+      parsedBody.message = 'Could not parse body';
+    }
+  }
+  return parsedBody;
+}

--- a/workflows/ci.js
+++ b/workflows/ci.js
@@ -3,8 +3,415 @@
 var self = ci;
 module.exports = self;
 
-function ci(externalBag, callback) {
-  // TODO: complete CI workflow
+var fs = require('fs-extra');
+var path = require('path');
+var executeJobScript = require('../_common/executeJobScript.js');
 
-  return callback();
+function ci(externalBag, callback) {
+  var bag = {
+    nodeId: config.nodeId,
+    jobId: externalBag.rawMessage.jobId,
+    ciSteps: externalBag.rawMessage.steps,
+    rawMessage: externalBag.rawMessage,
+    builderApiAdapter: externalBag.builderApiAdapter,
+    consoleAdapter: externalBag.consoleAdapter,
+    isCIJobCancelled: false,
+    mexecScriptDir: '/tmp/mexec',
+    mexecScriptRunner: 'scriptRunner.sh',
+    sshDir: '/tmp/ssh',
+    cexecDir: '/tmp/cexec',
+    cexecMessageName: 'message.json',
+    artifactsDir: '/shippableci',
+    onStartEnvDir: 'onstartjobenvs',
+    isSystemNode: config.isSystemNode
+  };
+
+  bag.who = util.format('%s|workflow|%s', msName, self.name);
+  logger.info(bag.who, 'Inside');
+
+  async.series([
+      _getJobStatus.bind(null, bag),
+      _getClusterNode.bind(null, bag),
+      _getSystemNode.bind(null, bag),
+      _validateCIJobMessage.bind(null, bag),
+      _validateCIJobStepsOrder.bind(null, bag),
+      _updateNodeIdInCIJob.bind(null, bag),
+      _createMexecDir.bind(null, bag),
+      _cleanOnStartEnvDir.bind(null, bag),
+      _cleanSSHDir.bind(null, bag),
+      _executeCIJob.bind(null, bag),
+      _updateJobStatus.bind(null, bag)
+    ],
+    function (err) {
+      return callback(err);
+    }
+  );
+}
+
+function _getJobStatus(bag, next) {
+  var who = bag.who + '|' + _getJobStatus.name;
+  logger.verbose(who, 'Inside');
+
+  bag.consoleAdapter.openGrp('Initializing Job');
+  bag.consoleAdapter.openCmd('Getting job');
+
+  bag.builderApiAdapter.getJobById(bag.jobId,
+    function (err, job) {
+      if (err) {
+        bag.consoleAdapter.publishMsg(util.format('Failed to get ' +
+          'job:%s with err:%s',bag.jobId, err));
+        bag.consoleAdapter.closeCmd(false);
+        bag.consoleAdapter.closeGrp(false);
+        bag.ciJobStatusCode = __getStatusCodeByNameForCI('FAILED');
+      } else {
+        bag.ciJob = job;
+
+        if (job.statusCode === __getStatusCodeByNameForCI('CANCELED') ||
+          job.statusCode === __getStatusCodeByNameForCI('TIMEOUT')) {
+            bag.isCIJobCancelled = true;
+            bag.consoleAdapter.publishMsg('Job:' + bag.jobId +
+              ' is canceled/timedout, skipping');
+            bag.consoleAdapter.closeCmd(true);
+        } else {
+          bag.consoleAdapter.publishMsg('Successfully fetched job');
+          bag.consoleAdapter.closeCmd(true);
+        }
+      }
+      return next();
+    }
+  );
+}
+
+function _getClusterNode(bag, next) {
+  if (bag.ciJobStatusCode) return next();
+  if (bag.isSystemNode) return next();
+  if (bag.isCIJobCancelled) return next();
+
+  var who = bag.who + '|' + _getClusterNode.name;
+  logger.verbose(who, 'Inside');
+
+  bag.consoleAdapter.openCmd('Getting node');
+
+  bag.builderApiAdapter.getClusterNodeById(bag.nodeId,
+    function (err) {
+      if (err) {
+        bag.consoleAdapter.publishMsg(util.inspect(err));
+        bag.consoleAdapter.closeCmd(false);
+        bag.consoleAdapter.closeGrp(false);
+        bag.ciJobStatusCode =
+          __getStatusCodeByNameForCI('FAILED');
+      } else {
+        bag.consoleAdapter.publishMsg('Successfully fetched node');
+        bag.consoleAdapter.closeCmd(true);
+      }
+
+      return next();
+    }
+  );
+}
+
+function _getSystemNode(bag, next) {
+  if (bag.ciJobStatusCode) return next();
+  if (!bag.isSystemNode) return next();
+  if (bag.isCIJobCancelled) return next();
+
+  var who = bag.who + '|' + _getSystemNode.name;
+  logger.verbose(who, 'Inside');
+
+  bag.consoleAdapter.openCmd('Getting node');
+
+  bag.builderApiAdapter.getSystemNodeById(bag.nodeId,
+    function (err) {
+      if (err) {
+        bag.consoleAdapter.publishMsg(util.inspect(err));
+        bag.consoleAdapter.closeCmd(false);
+        bag.consoleAdapter.closeGrp(false);
+        bag.ciJobStatusCode =
+          __getStatusCodeByNameForCI('FAILED');
+      } else {
+        bag.consoleAdapter.publishMsg('Successfully fetched node');
+        bag.consoleAdapter.closeCmd(true);
+      }
+
+      return next();
+    }
+  );
+}
+
+function _validateCIJobMessage(bag, next) {
+  if (bag.ciJobStatusCode) return next();
+  if (bag.isCIJobCancelled) return next();
+
+  var who = bag.who + '|' + _validateCIJobMessage.name;
+  logger.verbose(who, 'Inside');
+
+  bag.consoleAdapter.openCmd('Validating incoming message');
+  var consoleErrors = [];
+
+  if (_.isEmpty(bag.ciSteps))
+    consoleErrors.push('No steps found');
+  else {
+    _.each(bag.ciSteps,
+      function (step) {
+        if (!step.execOrder)
+          consoleErrors.push(
+            util.format('scriptType:%s is missing execOrder', step.scriptType));
+      }
+    );
+  }
+
+  if (consoleErrors.length > 0) {
+    _.each(consoleErrors,
+      function (e) {
+        bag.consoleAdapter.publishMsg(e);
+      }
+    );
+    bag.consoleAdapter.closeCmd(false);
+    bag.consoleAdapter.closeGrp(false);
+
+    bag.ciJobStatusCode =
+      __getStatusCodeByNameForCI('FAILED');
+  } else {
+    bag.consoleAdapter.publishMsg('Successfully validated incoming message');
+    bag.consoleAdapter.closeCmd(true);
+  }
+  return next();
+}
+
+function _validateCIJobStepsOrder(bag, next) {
+  if (bag.ciJobStatusCode) return next();
+  if (bag.isCIJobCancelled) return next();
+
+  var who = bag.who + '|' + _validateCIJobStepsOrder.name;
+  logger.verbose(who, 'Inside');
+
+  bag.consoleAdapter.openCmd('Validating steps order');
+
+  bag.ciStepsInSortedOrder = _.sortBy(bag.ciSteps, 'execOrder');
+
+  var bootIndex = _.findIndex(bag.ciStepsInSortedOrder,
+    {who: 'mexec', scriptType: 'boot'});
+
+  var errMsg;
+  if (!bag.ciStepsInSortedOrder[bootIndex + 1])
+    errMsg = 'Missing cexec step after boot step';
+  else if (bag.ciStepsInSortedOrder[bootIndex + 1].who !== 'cexec')
+    errMsg = 'Incorrect ordering of cexec step';
+
+  if (errMsg) {
+    bag.consoleAdapter.publishMsg(errMsg);
+    bag.consoleAdapter.closeCmd(false);
+    bag.consoleAdapter.closeGrp(false);
+    bag.ciJobStatusCode =
+      __getStatusCodeByNameForCI('FAILED');
+  } else {
+    bag.consoleAdapter.publishMsg('Successfully validated steps order');
+    bag.consoleAdapter.closeCmd(true);
+  }
+  return next();
+}
+
+function _updateNodeIdInCIJob(bag, next) {
+  if (bag.ciJobStatusCode) return next();
+  if (bag.isCIJobCancelled) return next();
+
+  var who = bag.who + '|' + _updateNodeIdInCIJob.name;
+  logger.verbose(who, 'Inside');
+  bag.consoleAdapter.openCmd('Updating node');
+
+  var update = {
+    node: bag.nodeId,
+    statusCode: __getStatusCodeByNameForCI('PROCESSING')
+  };
+
+  bag.builderApiAdapter.putJobById(bag.jobId, update,
+    function (err) {
+      if (err) {
+        var msg =
+          util.format('%s, failed to :putJobById for jobId: %s, %s',
+            who, bag.jobId, err);
+
+        bag.consoleAdapter.publishMsg(msg);
+        bag.consoleAdapter.closeCmd(false);
+        bag.consoleAdapter.closeGrp(false);
+
+        bag.ciJobStatusCode =
+          __getStatusCodeByNameForCI('FAILED');
+      } else {
+        bag.consoleAdapter.publishMsg('Successfully updated node in job');
+        bag.consoleAdapter.closeCmd(true);
+      }
+      return next();
+    }
+  );
+}
+
+function _createMexecDir(bag, next) {
+  if (bag.ciJobStatusCode) return next();
+  if (bag.isCIJobCancelled) return next();
+
+  var who = bag.who + '|' + _createMexecDir.name;
+  logger.verbose(who, 'Inside');
+
+  bag.consoleAdapter.openCmd('Creating mexec directory');
+
+  fs.mkdirp(bag.mexecScriptDir,
+    function (err) {
+      if (err) {
+        var msg =
+          util.format('%s, failed to create dir:%s with err:%s',
+            who, bag.mexecScriptDir, err);
+
+        bag.consoleAdapter.publishMsg(msg);
+        bag.consoleAdapter.closeCmd(false);
+        bag.consoleAdapter.closeGrp(false);
+
+        bag.ciJobStatusCode =
+          __getStatusCodeByNameForCI('FAILED');
+      } else {
+        bag.consoleAdapter.publishMsg('Successfully created mexec directory');
+        bag.consoleAdapter.closeCmd(true);
+      }
+      return next();
+    }
+  );
+}
+
+function _cleanOnStartEnvDir(bag, next) {
+  if (bag.ciJobStatusCode) return next();
+  if (bag.isCIJobCancelled) return next();
+
+  var jobEnvDir =  path.join(bag.artifactsDir, bag.onStartEnvDir);
+
+  var who = bag.who + '|' + _cleanOnStartEnvDir.name;
+  logger.verbose(who, 'Inside');
+
+  bag.consoleAdapter.openCmd('Cleaning onStartEnvDir directory');
+
+  fs.emptyDir(jobEnvDir,
+    function (err) {
+      if (err) {
+        var msg =
+          util.format('%s, failed to clean dir:%s with err:%s',
+            who, jobEnvDir, err);
+
+        bag.consoleAdapter.publishMsg(msg);
+        bag.consoleAdapter.closeCmd(false);
+        bag.consoleAdapter.closeGrp(false);
+
+        bag.ciJobStatusCode =
+          __getStatusCodeByNameForCI('FAILED');
+      } else {
+        bag.consoleAdapter.publishMsg('Successfully cleaned ' +
+          'onStartEnvDir directory');
+        bag.consoleAdapter.closeCmd(true);
+      }
+      return next();
+    }
+  );
+}
+
+function _cleanSSHDir(bag, next) {
+  if (bag.ciJobStatusCode) return next();
+  if (bag.isCIJobCancelled) return next();
+
+  var who = bag.who + '|' + _cleanSSHDir.name;
+  logger.verbose(who, 'Inside');
+
+  bag.consoleAdapter.openCmd('Cleaning ssh directory');
+
+  fs.emptyDir(bag.sshDir,
+    function (err) {
+      if (err) {
+        var msg =
+          util.format('%s, failed to clean dir:%s with err:%s',
+            who, bag.sshDir, err);
+
+        bag.consoleAdapter.publishMsg(msg);
+        bag.consoleAdapter.closeCmd(false);
+        bag.consoleAdapter.closeGrp(false);
+
+        bag.ciJobStatusCode =
+          __getStatusCodeByNameForCI('FAILED');
+      } else {
+        bag.consoleAdapter.publishMsg('Successfully cleaned ssh directory');
+        bag.consoleAdapter.closeCmd(true);
+        bag.consoleAdapter.closeGrp(true);
+      }
+      return next();
+    }
+  );
+}
+
+function _executeCIJob(bag, next) {
+  if (bag.ciJobStatusCode) return next();
+  if (bag.isCIJobCancelled) return next();
+
+  var who = bag.who + '|' + _executeCIJob.name;
+  logger.verbose(who, 'Inside');
+
+  var scriptBag = {
+    consoleAdapter: bag.consoleAdapter,
+    steps: bag.ciStepsInSortedOrder,
+    mexecFileNameWithPath: path.join(bag.mexecScriptDir,
+      bag.mexecScriptRunner),
+    ciJob: bag.ciJob,
+    jobEnvDir: path.join(bag.artifactsDir, bag.onStartEnvDir),
+    builderApiAdapter: bag.builderApiAdapter,
+    rawMessage: bag.rawMessage,
+    cexecMessageNameWithLocation: path.join(bag.cexecDir,
+      bag.cexecMessageName),
+    sshDir: bag.sshDir
+  };
+
+  executeJobScript(scriptBag,
+    function (err) {
+      if (err)
+        bag.ciJobStatusCode = __getStatusCodeByNameForCI('FAILED');
+
+      return next();
+    }
+  );
+}
+
+function _updateJobStatus(bag, next) {
+  if (bag.isCIJobCancelled) return next();
+
+  bag.consoleAdapter.openGrp('Updating Status');
+  bag.consoleAdapter.openCmd('Updating job status');
+
+  var who = bag.who + '|' + _updateJobStatus.name;
+  logger.verbose(who, 'Inside');
+
+  var update = {};
+
+  //ciJobStatusCode is only set to failed, so if we reach this
+  // function without any code we know job has succeeded
+  if (!bag.ciJobStatusCode)
+    bag.ciJobStatusCode =
+      __getStatusCodeByNameForCI('SUCCESS');
+
+  update.statusCode = bag.ciJobStatusCode;
+
+  bag.builderApiAdapter.putJobById(bag.jobId, update,
+    function (err) {
+      if (err) {
+        var msg = util.format('%s, failed to :putJobById for ' +
+          'jobId: %s with err: %s', who, bag.jobId, err);
+        bag.consoleAdapter.publishMsg(msg);
+        bag.consoleAdapter.closeCmd(false);
+        bag.consoleAdapter.closeGrp(false);
+      } else {
+        bag.consoleAdapter.publishMsg('Successfully updated job status');
+        bag.consoleAdapter.closeCmd(true);
+        bag.consoleAdapter.closeGrp(true);
+      }
+      return next();
+    }
+  );
+}
+
+function __getStatusCodeByNameForCI(codeName) {
+  return _.findWhere(global.systemCodes,
+    { group: 'statusCodes', name: codeName}).code;
 }


### PR DESCRIPTION
https://github.com/Shippable/reqProc/issues/97

This PR copies the same code of legacy ci from genExec to reqProc.

Was able to successfully run build on local.
![image](https://user-images.githubusercontent.com/4211715/32493072-892005a8-c3e2-11e7-930a-b8cb17bddc1e.png)

Right now there is only one dependent script ( `_common/executeJobScript.js` ). We will move this to a more appropriate folder which will group the files that deal with legacy ci. ( Will do this process in the next issue or at the end, based on the upcoming changes )
 
