### PR TITLE
#236; uses ciRepo sourceName from version.

### DIFF
--- a/job/handlers/resources/_common/ciRepo/outStep.js
+++ b/job/handlers/resources/_common/ciRepo/outStep.js
@@ -41,9 +41,14 @@ function _checkInputParams(bag, next) {
   bag.replicate = bag.dependency.versionDependencyPropertyBag &&
     bag.dependency.versionDependencyPropertyBag.replicate;
 
-  if (!bag.replicate && !bag.dependency.sourceName)
+  bag.sourceName = bag.dependency.version &&
+    bag.dependency.version.propertyBag &&
+    bag.dependency.version.propertyBag.sourceName;
+
+  if (!bag.replicate && !bag.sourceName)
     consoleErrors.push(
-      util.format('%s is missing: dependency.sourceName', who)
+      util.format('%s is missing: dependency.version.propertyBag.sourceName',
+        who)
     );
 
   if (!bag.replicate && !bag.dependency.version.versionName)
@@ -132,7 +137,7 @@ function _generateNewVersion(bag, next) {
       var isSourceNameEqual = (dependency.version &&
         dependency.version.propertyBag &&
         dependency.version.propertyBag.sourceName) ===
-        bag.dependency.sourceName;
+        bag.sourceName;
       var isProviderEqual =
         dependency.propertyBag.normalizedRepo &&
         (dependency.propertyBag.normalizedRepo.repositoryProvider ===

--- a/runCI/resources/ciRepo/outStep.js
+++ b/runCI/resources/ciRepo/outStep.js
@@ -40,9 +40,14 @@ function _checkInputParams(bag, next) {
   bag.replicate = bag.dependency.versionDependencyPropertyBag &&
     bag.dependency.versionDependencyPropertyBag.replicate;
 
-  if (!bag.replicate && !bag.dependency.sourceName)
+  bag.sourceName = bag.dependency.version &&
+    bag.dependency.version.propertyBag &&
+    bag.dependency.version.propertyBag.sourceName;
+
+  if (!bag.replicate && !bag.sourceName)
     consoleErrors.push(
-      util.format('%s is missing: dependency.sourceName', who)
+      util.format('%s is missing: dependency.version.propertyBag.sourceName',
+        who)
     );
 
   if (!bag.replicate && !bag.dependency.version.versionName)
@@ -131,7 +136,7 @@ function _generateNewVersion(bag, next) {
       var isSourceNameEqual = (dependency.version &&
         dependency.version.propertyBag &&
         dependency.version.propertyBag.sourceName) ===
-        bag.dependency.sourceName;
+        bag.sourceName;
       var isProviderEqual =
         dependency.propertyBag.normalizedRepo &&
         (dependency.propertyBag.normalizedRepo.repositoryProvider ===


### PR DESCRIPTION
#236 

Tested a runSh job with a gitRepo input and ciRepo output.  A new ciRepo version was posted when the sourceNames matched, and not when they didn't.