### PR TITLE
#250; avoids repeating quotes in the template.

### DIFF
--- a/workflows/runCI.js
+++ b/workflows/runCI.js
@@ -888,9 +888,13 @@ function __generateReplaceScript(bag, seriesParams, next) {
 
   var envs = _.map(bag.paramEnvs.concat(bag.commonEnvs),
     function (env) {
+      var value = env.split('=')[1];
+      if (_.isString(value) && value[0] === '"' &&
+        value[value.length - 1] === '"')
+        value = value.substring(1, value.length - 1);
       return {
         key: env.split('=')[0],
-        value: env.split('=')[1]
+        value: value
       };
     }
   );


### PR DESCRIPTION
#250 

Removes the double quotes surrounding double-quoted values to avoid repeating the quotes currently in the `envs` templates.