### PR TITLE
Removes BOM character

### DIFF
--- a/job/postVersion.js
+++ b/job/postVersion.js
@@ -133,6 +133,9 @@ function _extendOutputVersionWithEnvs(bag, next) {
   var propertyBag = {};
   try {
     var envFile = fs.readFileSync(envFilePath).toString();
+    // Remove BOM characters which get added in case of Windows
+    // Refer https://github.com/nodejs/node-v0.x-archive/issues/1918
+    envFile = envFile.replace(/^\uFEFF/, '');
     var lines = envFile.split('\n');
     bag.consoleAdapter.publishMsg(
       util.format('Found file %s. Checking for additional properties.',
@@ -448,6 +451,9 @@ function __readVersionEnv(bag, next) {
     bag.dependency.name));
   try {
     var envFile = fs.readFileSync(envFilePath).toString();
+    // Remove BOM characters which get added in case of Windows
+    // Refer https://github.com/nodejs/node-v0.x-archive/issues/1918
+    envFile = envFile.replace(/^\uFEFF/, '');
     var lines = envFile.split('\n');
 
     _.each(lines,


### PR DESCRIPTION
https://github.com/Shippable/reqProc/issues/274
 
Tested with

```yml
  - name: x86-64-windows-server-2016-host-out-image-post
    type: runSh
    runtime:
      architecture: x86_64
      os: WindowsServer_2016
      container: false
    flags:
      - x86-64
      - windows-server-2016
      - x86-64-windows-server-2016-host-out
    steps:
      - IN: x86-64-trigger
      - IN: windows-server-2016-trigger
      - OUT: master-image-1
        overwrite: true
      - TASK:
          name: should-post-resource-state
          script:
            - gci env:*
            - if ( "$env:MASTERIMAGE1_NAME" -ne "master-image-1" ) { Write-Error "incorrect env" }
            - '"versionName=master.$env:BUILD_NUMBER" | Out-File -Encoding utf8 -FilePath $env:JOB_STATE\$env:MASTERIMAGE1_NAME.env -NoNewLine'

  - name: x86-64-windows-server-2016-host-out-image-put
    type: runSh
    runtime:
      architecture: x86_64
      os: WindowsServer_2016
      container: false
    flags:
      - x86-64
      - windows-server-2016
      - x86-64-windows-server-2016-host-out
    steps:
      - IN: x86-64-trigger
      - IN: windows-server-2016-trigger
      - OUT: master-image-1
      - TASK:
          name: should-put-resource-state
          script:
            - gci env:*
            - if ( "$env:MASTERIMAGE1_NAME" -ne "master-image-1" ) { Write-Error "incorrect env" }
            - '"key.$env:BUILD_NUMBER=value.$env:BUILD_NUMBER" | Out-File -Append -Encoding utf8 -FilePath $env:JOB_STATE\$env:MASTERIMAGE1_NAME.env -NoNewLine'
            - '"`nkey2.$env:BUILD_NUMBER=value2.$env:BUILD_NUMBER" | Out-File -Append -Encoding utf8 -FilePath $env:JOB_STATE\$env:MASTERIMAGE1_NAME.env -NoNewLine'
            - cat $env:JOB_STATE\$env:MASTERIMAGE1_NAME.env

  - name: x86-64-ubuntu-16-04-host-out-image-post
    type: runSh
    runtime:
      architecture: x86_64
      os: Ubuntu_16.04
      container: false
    flags:
      - x86-64
      - ubuntu-16-04
      - x86-64-ubuntu-16-04-host-out
    steps:
      - IN: x86-64-trigger
      - IN: windows-server-2016-trigger
      - OUT: master-image-1
        overwrite: true
      - TASK:
          name: should-post-resource-state
          script:
            - printenv
            - echo "versionName=master.$BUILD_NUMBER" > $JOB_STATE/$MASTERIMAGE1_NAME.env

  - name: x86-64-ubuntu-16-04-host-out-image-put
    type: runSh
    runtime:
      architecture: x86_64
      os: Ubuntu_16.04
      container: false
    flags:
      - x86-64
      - ubuntu-16-04
      - x86-64-ubuntu-16-04-host-out
    steps:
      - IN: x86-64-trigger
      - IN: windows-server-2016-trigger
      - OUT: master-image-1
      - TASK:
          name: should-put-resource-state
          script:
            - printenv
            - echo "key.$BUILD_NUMBER=value.$BUILD_NUMBER" >> $JOB_STATE/$MASTERIMAGE1_NAME.env
            - echo "key2.$BUILD_NUMBER=value2.$BUILD_NUMBER" >> $JOB_STATE/$MASTERIMAGE1_NAME.env
```