### PR TITLE
#280; updates error messages for missing gitRepo version or shaData.

### DIFF
--- a/job/handlers/resources/Ubuntu_14.04/gitRepo/inStep.js
+++ b/job/handlers/resources/Ubuntu_14.04/gitRepo/inStep.js
@@ -45,14 +45,20 @@ function _checkInputParams(bag, next) {
   var consoleErrors = [];
 
   if (!bag.dependency.propertyBag.normalizedRepo)
-    consoleErrors.push(who +
-      ' Missing parameter: dependency.propertyBag.normalizedRepo');
+    consoleErrors.push(
+      util.format('%s gitRepo %s is missing required repository information.',
+        who, bag.dependency.name)
+    );
 
   if (!bag.dependency.version ||
     _.isEmpty(bag.dependency.version.propertyBag) ||
     _.isEmpty(bag.dependency.version.propertyBag.shaData))
-    consoleErrors.push(who +
-      ' Missing parameter: dependency.version.propertyBag.shaData');
+    consoleErrors.push(
+      util.format('%s gitRepo %s version %s does not have shaData. ' +
+        'Create a new version by webhook before using this resource. ',
+        who, bag.dependency.name,
+        bag.dependency.version && bag.dependency.version.versionNumber)
+    );
 
   if (consoleErrors.length > 0) {
     _.each(consoleErrors,

--- a/job/handlers/resources/Ubuntu_16.04/gitRepo/inStep.js
+++ b/job/handlers/resources/Ubuntu_16.04/gitRepo/inStep.js
@@ -45,14 +45,20 @@ function _checkInputParams(bag, next) {
   var consoleErrors = [];
 
   if (!bag.dependency.propertyBag.normalizedRepo)
-    consoleErrors.push(who +
-      ' Missing parameter: dependency.propertyBag.normalizedRepo');
+    consoleErrors.push(
+      util.format('%s gitRepo %s is missing required repository information.',
+        who, bag.dependency.name)
+    );
 
   if (!bag.dependency.version ||
     _.isEmpty(bag.dependency.version.propertyBag) ||
     _.isEmpty(bag.dependency.version.propertyBag.shaData))
-    consoleErrors.push(who +
-      ' Missing parameter: dependency.version.propertyBag.shaData');
+    consoleErrors.push(
+      util.format('%s gitRepo %s version %s does not have shaData. ' +
+        'Create a new version by webhook before using this resource. ',
+        who, bag.dependency.name,
+        bag.dependency.version && bag.dependency.version.versionNumber)
+    );
 
   if (consoleErrors.length > 0) {
     _.each(consoleErrors,

--- a/job/handlers/resources/WindowsServer_2016/gitRepo/inStep.js
+++ b/job/handlers/resources/WindowsServer_2016/gitRepo/inStep.js
@@ -44,14 +44,20 @@ function _checkInputParams(bag, next) {
   var consoleErrors = [];
 
   if (!bag.dependency.propertyBag.normalizedRepo)
-    consoleErrors.push(who +
-      ' Missing parameter: dependency.propertyBag.normalizedRepo');
+    consoleErrors.push(
+      util.format('%s gitRepo %s is missing required repository information.',
+        who, bag.dependency.name)
+    );
 
   if (!bag.dependency.version ||
     _.isEmpty(bag.dependency.version.propertyBag) ||
     _.isEmpty(bag.dependency.version.propertyBag.shaData))
-    consoleErrors.push(who +
-      ' Missing parameter: dependency.version.propertyBag.shaData');
+    consoleErrors.push(
+      util.format('%s gitRepo %s version %s does not have shaData. ' +
+        'Create a new version by webhook before using this resource. ',
+        who, bag.dependency.name,
+        bag.dependency.version && bag.dependency.version.versionNumber)
+    );
 
   if (consoleErrors.length > 0) {
     _.each(consoleErrors,

--- a/job/handlers/resources/macOS_10.12/gitRepo/inStep.js
+++ b/job/handlers/resources/macOS_10.12/gitRepo/inStep.js
@@ -45,14 +45,20 @@ function _checkInputParams(bag, next) {
   var consoleErrors = [];
 
   if (!bag.dependency.propertyBag.normalizedRepo)
-    consoleErrors.push(who +
-      ' Missing parameter: dependency.propertyBag.normalizedRepo');
+    consoleErrors.push(
+      util.format('%s gitRepo %s is missing required repository information.',
+        who, bag.dependency.name)
+    );
 
   if (!bag.dependency.version ||
     _.isEmpty(bag.dependency.version.propertyBag) ||
     _.isEmpty(bag.dependency.version.propertyBag.shaData))
-    consoleErrors.push(who +
-      ' Missing parameter: dependency.version.propertyBag.shaData');
+    consoleErrors.push(
+      util.format('%s gitRepo %s version %s does not have shaData. ' +
+        'Create a new version by webhook before using this resource. ',
+        who, bag.dependency.name,
+        bag.dependency.version && bag.dependency.version.versionNumber)
+    );
 
   if (consoleErrors.length > 0) {
     _.each(consoleErrors,

--- a/job/initializeJob.js
+++ b/job/initializeJob.js
@@ -231,21 +231,24 @@ function _validateDependencies(bag, next) {
 
       if (!_.isObject(dependency.version) && dependency.operation !== 'OUT')
         dependencyErrors.push(
-          util.format('%s, %s dependency is missing :version',
-            who, dependency.name)
+          util.format('Dependency %s has no version. ' +
+            'A version must exist in order to use it as an input.',
+            dependency.name)
         );
 
       if (_.isObject(dependency.version) && dependency.operation !== 'OUT') {
         if (!dependency.version.versionId)
           dependencyErrors.push(
-            util.format('%s dependency is missing :version.versionId',
+            util.format('Dependency %s is missing a valid version. ' +
+              'A version must exist in order to use it as an input.',
               dependency.name)
           );
 
         if (!_.isObject(dependency.version.propertyBag))
           dependencyErrors.push(
-            util.format('%s dependency is missing :version.propertyBag',
-              dependency.name)
+            util.format('Dependency %s does not have a valid version. ' +
+              'Version %s does not have a propertyBag.',
+              dependency.name, dependency.version.versionId)
           );
       }
 

--- a/runCI/resources/gitRepo/inStep.js
+++ b/runCI/resources/gitRepo/inStep.js
@@ -44,14 +44,20 @@ function _checkInputParams(bag, next) {
   var consoleErrors = [];
 
   if (!bag.dependency.propertyBag.normalizedRepo)
-    consoleErrors.push(who +
-      ' Missing parameter: dependency.propertyBag.normalizedRepo');
+    consoleErrors.push(
+      util.format('%s gitRepo %s is missing required repository information.',
+        who, bag.dependency.name)
+    );
 
   if (!bag.dependency.version ||
     _.isEmpty(bag.dependency.version.propertyBag) ||
     _.isEmpty(bag.dependency.version.propertyBag.shaData))
-    consoleErrors.push(who +
-      ' Missing parameter: dependency.version.propertyBag.shaData');
+    consoleErrors.push(
+      util.format('%s gitRepo %s version %s does not have shaData. ' +
+        'Create a new version by webhook before using this resource. ',
+        who, bag.dependency.name,
+        bag.dependency.version && bag.dependency.version.versionNumber)
+    );
 
   if (consoleErrors.length > 0) {
     _.each(consoleErrors,

--- a/workflows/runCI.js
+++ b/workflows/runCI.js
@@ -378,21 +378,24 @@ function _validateDependencies(bag, next) {
 
       if (!_.isObject(dependency.version) && dependency.operation !== 'OUT')
         dependencyErrors.push(
-          util.format('%s, %s dependency is missing :version',
-            who, dependency.name)
+          util.format('Dependency %s has no version. ' +
+            'A version must exist in order to use it as an input.',
+            dependency.name)
         );
 
       if (_.isObject(dependency.version) && dependency.operation !== 'OUT') {
         if (!dependency.version.versionId)
           dependencyErrors.push(
-            util.format('%s dependency is missing :version.versionId',
+            util.format('Dependency %s is missing a valid version. ' +
+              'A version must exist in order to use it as an input.',
               dependency.name)
           );
 
         if (!_.isObject(dependency.version.propertyBag))
           dependencyErrors.push(
-            util.format('%s dependency is missing :version.propertyBag',
-              dependency.name)
+            util.format('Dependency %s does not have a valid version. ' +
+              'Version %s does not have a propertyBag.',
+                dependency.name, dependency.version.versionId)
           );
       }
 


### PR DESCRIPTION
#280 

Updated to match genExec.  Tested runSh and runCI on Ubuntu 16.04 with no version and with no shaData.  The runCI job failed on an earlier error when the version did not exist (stating that there were no versions).