### PR TITLE
adds no cache option for windows docker build

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -30,7 +30,7 @@ Function set_build_context() {
 }
 
 Function build_and_tag_image() {
-  docker build -f ./image/$ARCHITECTURE/$OS/Dockerfile -t "$HUB_IMAGE" .
+  docker build --no-cache -f ./image/$ARCHITECTURE/$OS/Dockerfile -t "$HUB_IMAGE" .
 }
 
 Function push_images() {


### PR DESCRIPTION
https://github.com/Shippable/reqProc/issues/294

Adding `--no-cache` as we just have one windows node for building images and it is always using the cache and the latest code changes are not being reflected. So, making the build process to do a fresh build and push every time.