### PR TITLE
#297; removes leading numbers from generated variable names.

### DIFF
--- a/job/setupDependencies.js
+++ b/job/setupDependencies.js
@@ -109,7 +109,8 @@ function _setUpDependencies(bag, next) {
     return next('No yml found for job steps');
   }
 
-  var jobName = bag.inPayload.name.replace(/[^A-Za-z0-9_]/g, '').toUpperCase();
+  var jobName = bag.inPayload.name.replace(/[^A-Za-z0-9_]/g, '').
+    replace(/^[0-9]+/g, '').toUpperCase();
 
   bag.commonEnvs = [
     {
@@ -465,8 +466,8 @@ function __addDependencyEnvironmentVariables(bag, seriesParams, next) {
 
   var dependency = seriesParams.dependency;
 
-  var sanitizedDependencyName =
-    dependency.name.replace(/[^A-Za-z0-9_]/g, '').toUpperCase();
+  var sanitizedDependencyName = dependency.name.replace(/[^A-Za-z0-9_]/g, '').
+    replace(/^[0-9]+/g, '').toUpperCase();
 
   var dependencyPath = path.join(bag.buildRootDir, dependency.operation,
     dependency.name);
@@ -827,7 +828,7 @@ function __getDependencyIntegrations(bag, seriesParams, next) {
 
       // add integrations to environment variables
       var sanitizedDependencyName = seriesParams.dependency.name.
-        replace(/[^A-Za-z0-9_]/g, '').toUpperCase();
+        replace(/[^A-Za-z0-9_]/g, '').replace(/^[0-9]+/g, '').toUpperCase();
       var stringAndArrayData = _.extend(_.clone(stringData), arrayData);
 
       // environment variables should have objects flattened

--- a/workflows/runCI.js
+++ b/workflows/runCI.js
@@ -729,7 +729,8 @@ function _setUpDependencies(bag, next) {
     return next('No yml found for job steps');
   }
 
-  var jobName = bag.inPayload.name.replace(/[^A-Za-z0-9_]/g, '').toUpperCase();
+  var jobName = bag.inPayload.name.replace(/[^A-Za-z0-9_]/g, '').
+    replace(/^[0-9]+/g, '').toUpperCase();
 
   bag.commonEnvs = [
     util.format('RESOURCE_ID=%s', bag.resourceId),
@@ -1017,8 +1018,8 @@ function __addDependencyEnvironmentVariables(bag, seriesParams, next) {
 
   var dependency = seriesParams.dependency;
 
-  var sanitizedDependencyName =
-    dependency.name.replace(/[^A-Za-z0-9_]/g, '').toUpperCase();
+  var sanitizedDependencyName = dependency.name.replace(/[^A-Za-z0-9_]/g, '').
+    replace(/^[0-9]+/g, '').toUpperCase();
 
   var dependencyPath = bag.buildRootDir + '/' +
     dependency.operation + '/' + dependency.name;
@@ -1361,7 +1362,7 @@ function __getDependencyIntegrations(bag, seriesParams, next) {
 
       // add integrations to environment variables
       var sanitizedDependencyName = seriesParams.dependency.name.
-        replace(/[^A-Za-z0-9_]/g, '').toUpperCase();
+        replace(/[^A-Za-z0-9_]/g, '').replace(/^[0-9]+/g, '').toUpperCase();
       var stringAndArrayData = _.extend(_.clone(stringData), arrayData);
 
       // environment variables should have objects flattened


### PR DESCRIPTION
#297 

The same as for genExec.  This removes leading numbers from resource names when using them as environment variable names to create valid environment variables.  Tested with jobs and inputs starting with numbers in runCi and runSh.  Numbers that are not at the beginning of the name remain, and leading numbers are removed.