### PR TITLE
Move PEM key path for gitRepo from /tmp to /build/secrets for Ubuntu 14.04

### DIFF
--- a/job/handlers/handleDependency.js
+++ b/job/handlers/handleDependency.js
@@ -22,6 +22,7 @@ function handleDependency(externalBag, dependency, callback) {
     buildInDir: externalBag.buildInDir,
     buildOutDir: externalBag.buildOutDir,
     buildScriptsDir: externalBag.buildScriptsDir,
+    buildSecretsDir: externalBag.buildSecretsDir,
     stepMessageFilename: externalBag.stepMessageFilename
   };
   bag.who = util.format('%s|job|handlers|%s', msName, self.name);
@@ -138,7 +139,8 @@ function _handleDependency(bag, dependency, next) {
     inPayload: bag.inPayload,
     rootDir: rootDir,
     stepMessageFilename: bag.stepMessageFilename,
-    buildScriptsDir: bag.buildScriptsDir
+    buildScriptsDir: bag.buildScriptsDir,
+    buildSecretsDir: bag.buildSecretsDir
   };
 
   dependencyHandler(params,

--- a/job/handlers/resources/Ubuntu_14.04/gitRepo/inStep.js
+++ b/job/handlers/resources/Ubuntu_14.04/gitRepo/inStep.js
@@ -6,13 +6,13 @@ var path = require('path');
 var executeDependencyScript = require('../../../executeDependencyScript.js');
 
 function inStep(params, callback) {
-//function inStep(externalBag, dependency, buildInDir, callback) {
   var bag = {
     resBody: {},
     subPrivateKeyPath: params.bag.subPrivateKeyPath,
     dependency: params.dependency,
     templatePath: path.resolve(__dirname, 'templates/inStep.sh'),
     buildInDir: params.rootDir,
+    buildSecretsDir: params.buildSecretsDir,
     scriptName: 'inStep.sh',
     builderApiAdapter: params.builderApiAdapter,
     consoleAdapter: params.consoleAdapter
@@ -23,7 +23,7 @@ function inStep(params, callback) {
   logger.verbose(bag.who, 'Starting');
 
   bag.scriptPath =
-   path.join(bag.buildInDir, bag.dependency.name, bag.scriptName);
+    path.join(bag.buildInDir, bag.dependency.name, bag.scriptName);
 
   async.series([
       _checkInputParams.bind(null, bag),
@@ -100,6 +100,8 @@ function _injectDependencies(bag, next) {
 
   bag.dependency.cloneLocation = path.join(bag.buildInDir,
     bag.dependency.name, bag.dependency.type);
+  bag.dependency.keyLocation = path.join(bag.buildSecretsDir,
+    bag.dependency.name + '_key.pem');
   bag.dependency.commitSha = bag.dependency.version.versionName;
   bag.dependency.shaData = bag.dependency.version.propertyBag.shaData;
   bag.dependency.subPrivateKeyPath = bag.subPrivateKeyPath;

--- a/job/handlers/resources/Ubuntu_14.04/gitRepo/templates/providers/_bitbucket.sh
+++ b/job/handlers/resources/Ubuntu_14.04/gitRepo/templates/providers/_bitbucket.sh
@@ -28,13 +28,14 @@ export PULL_REQUEST_SOURCE_URL="<%=shaData.pullRequestSourceUrl%>"
 export PULL_REQUEST_BASE_BRANCH="<%=shaData.pullRequestBaseBranch%>"
 export PROJECT="<%=name%>"
 export SUBSCRIPTION_PRIVATE_KEY_PATH="<%=subPrivateKeyPath%>"
+export PROJECT_KEY_LOCATION="<%=keyLocation%>"
 
 git_sync() {
-  echo "$PRIVATE_KEY" > /tmp/"$PROJECT"_key.pem
-  chmod 600 /tmp/"$PROJECT"_key.pem
+  echo "$PRIVATE_KEY" > $PROJECT_KEY_LOCATION
+  chmod 600 $PROJECT_KEY_LOCATION
   git config --global credential.helper store
 
-  shippable_retry ssh-agent bash -c "ssh-add /tmp/"$PROJECT"_key.pem; git clone $PROJECT_CLONE_URL $PROJECT_CLONE_LOCATION"
+  shippable_retry ssh-agent bash -c "ssh-add $PROJECT_KEY_LOCATION; git clone $PROJECT_CLONE_URL $PROJECT_CLONE_LOCATION"
 
   echo "----> Pushing Directory $PROJECT_CLONE_LOCATION"
   pushd $PROJECT_CLONE_LOCATION

--- a/job/handlers/resources/Ubuntu_14.04/gitRepo/templates/providers/_github.sh
+++ b/job/handlers/resources/Ubuntu_14.04/gitRepo/templates/providers/_github.sh
@@ -27,13 +27,14 @@ export IS_PULL_REQUEST_CLOSE=<%=shaData.isPullRequestClose%>
 export PULL_REQUEST="<%=shaData.pullRequestNumber%>"
 export PULL_REQUEST_BASE_BRANCH="<%=shaData.pullRequestBaseBranch%>"
 export PROJECT="<%=name%>"
+export PROJECT_KEY_LOCATION="<%=keyLocation%>"
 
 git_sync() {
-  echo "$PRIVATE_KEY" > /tmp/"$PROJECT"_key.pem
-  chmod 600 /tmp/"$PROJECT"_key.pem
+  echo "$PRIVATE_KEY" > $PROJECT_KEY_LOCATION
+  chmod 600 $PROJECT_KEY_LOCATION
   git config --global credential.helper store
 
-  shippable_retry ssh-agent bash -c "ssh-add /tmp/"$PROJECT"_key.pem; git clone $PROJECT_CLONE_URL $PROJECT_CLONE_LOCATION"
+  shippable_retry ssh-agent bash -c "ssh-add $PROJECT_KEY_LOCATION; git clone $PROJECT_CLONE_URL $PROJECT_CLONE_LOCATION"
 
   echo "----> Pushing Directory $PROJECT_CLONE_LOCATION"
   pushd $PROJECT_CLONE_LOCATION
@@ -44,7 +45,7 @@ git_sync() {
 
   echo "----> Checking out commit SHA"
   if [ "$IS_PULL_REQUEST" != false ]; then
-    shippable_retry ssh-agent bash -c "ssh-add /tmp/"$PROJECT"_key.pem; git fetch origin pull/$PULL_REQUEST/head"
+    shippable_retry ssh-agent bash -c "ssh-add $PROJECT_KEY_LOCATION; git fetch origin pull/$PULL_REQUEST/head"
     git checkout -f FETCH_HEAD
     git merge origin/$PULL_REQUEST_BASE_BRANCH
   else

--- a/job/handlers/resources/Ubuntu_14.04/gitRepo/templates/providers/_gitlab.sh
+++ b/job/handlers/resources/Ubuntu_14.04/gitRepo/templates/providers/_gitlab.sh
@@ -27,13 +27,14 @@ export IS_PULL_REQUEST_CLOSE=<%=shaData.isPullRequestClose%>
 export PULL_REQUEST="<%=shaData.pullRequestNumber%>"
 export PULL_REQUEST_BASE_BRANCH="<%=shaData.pullRequestBaseBranch%>"
 export PROJECT="<%=name%>"
+export PROJECT_KEY_LOCATION="<%=keyLocation%>"
 
 git_sync() {
-  echo "$PRIVATE_KEY" > /tmp/"$PROJECT"_key.pem
-  chmod 600 /tmp/"$PROJECT"_key.pem
+  echo "$PRIVATE_KEY" > $PROJECT_KEY_LOCATION
+  chmod 600 $PROJECT_KEY_LOCATION
   git config --global credential.helper store
 
-  shippable_retry ssh-agent bash -c "ssh-add /tmp/"$PROJECT"_key.pem; git clone $PROJECT_CLONE_URL $PROJECT_CLONE_LOCATION"
+  shippable_retry ssh-agent bash -c "ssh-add $PROJECT_KEY_LOCATION; git clone $PROJECT_CLONE_URL $PROJECT_CLONE_LOCATION"
 
   echo "----> Pushing Directory $PROJECT_CLONE_LOCATION"
   pushd $PROJECT_CLONE_LOCATION
@@ -44,7 +45,7 @@ git_sync() {
 
   echo "----> Checking out commit SHA"
   if [ "$IS_PULL_REQUEST" != false ]; then
-    shippable_retry ssh-agent bash -c "ssh-add /tmp/"$PROJECT"_key.pem; git fetch origin merge-requests/$PULL_REQUEST/head"
+    shippable_retry ssh-agent bash -c "ssh-add $PROJECT_KEY_LOCATION; git fetch origin merge-requests/$PULL_REQUEST/head"
     git checkout -f FETCH_HEAD
     git merge origin/$PULL_REQUEST_BASE_BRANCH
   else

--- a/job/processINs.js
+++ b/job/processINs.js
@@ -17,7 +17,8 @@ function processINs(externalBag, callback) {
     buildOutDir: externalBag.buildOutDir,
     stepMessageFilename: externalBag.stepMessageFilename,
     subPrivateKeyPath: externalBag.subPrivateKeyPath,
-    buildScriptsDir: externalBag.buildScriptsDir
+    buildScriptsDir: externalBag.buildScriptsDir,
+    buildSecretsDir: externalBag.buildSecretsDir
   };
   bag.who = util.format('%s|job|%s', msName, self.name);
   logger.info(bag.who, 'Inside');

--- a/job/setupDependencies.js
+++ b/job/setupDependencies.js
@@ -27,7 +27,8 @@ function setupDependencies(externalBag, callback) {
     stepMessageFilename: externalBag.stepMessageFilename,
     buildSharedDir: externalBag.buildSharedDir,
     subPrivateKeyPath: externalBag.subPrivateKeyPath,
-    buildScriptsDir: externalBag.buildScriptsDir
+    buildScriptsDir: externalBag.buildScriptsDir,
+    buildSecretsDir: externalBag.buildSecretsDir
   };
 
   bag.who = util.format('%s|job|%s', msName, self.name);
@@ -640,7 +641,7 @@ function __addDependencyEnvironmentVariables(bag, seriesParams, next) {
         });
         bag.commonEnvs.push({
           key: util.format('%s_KEYPATH', sanitizedDependencyName),
-          value: '/tmp/' + dependency.name + '_key.pem'
+          value: path.join(bag.buildSecretsDir, dependency.name + '_key.pem')
         });
         bag.commonEnvs.push({
           key: util.format('%s_IS_PULL_REQUEST', sanitizedDependencyName),


### PR DESCRIPTION
**Note:** While the basic scenarios for public and privates projects have been tested for Github, Gitlab, and Bitbucket, this still needs extensive testing for all scenarios including pull requests, releases, tags etc. Also, the actual usage of the key itself needs to be tested. The [repo here](https://github.com/shriv-ra/fuzzy-system/blob/pm-10110/shippable.yml) covers the basic cases.

https://github.com/Shippable/reqProc/issues/326