### PR TITLE
Update generic inStep.sh to save gitRepo PEM key in /build/secrets

### DIFF
--- a/job/handlers/resources/CentOS_7/gitRepo/templates/inStep.sh
+++ b/job/handlers/resources/CentOS_7/gitRepo/templates/inStep.sh
@@ -23,13 +23,14 @@ export PROJECT_CLONE_URL="<%=projectUrl%>"
 export PROJECT_CLONE_LOCATION="<%=cloneLocation%>"
 export COMMIT_SHA="<%=commitSha%>"
 export PROJECT="<%=name%>"
+export PROJECT_KEY_LOCATION="<%=keyLocation%>"
 
 git_sync() {
-  echo "$PRIVATE_KEY" > /tmp/"$PROJECT"_key.pem
-  chmod 600 /tmp/"$PROJECT"_key.pem
+  echo "$PRIVATE_KEY" > $PROJECT_KEY_LOCATION
+  chmod 600 $PROJECT_KEY_LOCATION
   git config --global credential.helper store
 
-  ssh-agent bash -c "ssh-add /tmp/"$PROJECT"_key.pem; git clone $PROJECT_CLONE_URL $PROJECT_CLONE_LOCATION"
+  ssh-agent bash -c "ssh-add $PROJECT_KEY_LOCATION; git clone $PROJECT_CLONE_URL $PROJECT_CLONE_LOCATION"
 
   echo "----> Pushing Directory $PROJECT_CLONE_LOCATION"
   pushd $PROJECT_CLONE_LOCATION

--- a/job/handlers/resources/Ubuntu_14.04/gitRepo/templates/inStep.sh
+++ b/job/handlers/resources/Ubuntu_14.04/gitRepo/templates/inStep.sh
@@ -23,13 +23,14 @@ export PROJECT_CLONE_URL="<%=projectUrl%>"
 export PROJECT_CLONE_LOCATION="<%=cloneLocation%>"
 export COMMIT_SHA="<%=commitSha%>"
 export PROJECT="<%=name%>"
+export PROJECT_KEY_LOCATION="<%=keyLocation%>"
 
 git_sync() {
-  echo "$PRIVATE_KEY" > /tmp/"$PROJECT"_key.pem
-  chmod 600 /tmp/"$PROJECT"_key.pem
+  echo "$PRIVATE_KEY" > $PROJECT_KEY_LOCATION
+  chmod 600 $PROJECT_KEY_LOCATION
   git config --global credential.helper store
 
-  ssh-agent bash -c "ssh-add /tmp/"$PROJECT"_key.pem; git clone $PROJECT_CLONE_URL $PROJECT_CLONE_LOCATION"
+  ssh-agent bash -c "ssh-add $PROJECT_KEY_LOCATION; git clone $PROJECT_CLONE_URL $PROJECT_CLONE_LOCATION"
 
   echo "----> Pushing Directory $PROJECT_CLONE_LOCATION"
   pushd $PROJECT_CLONE_LOCATION

--- a/job/handlers/resources/Ubuntu_16.04/gitRepo/templates/inStep.sh
+++ b/job/handlers/resources/Ubuntu_16.04/gitRepo/templates/inStep.sh
@@ -23,13 +23,14 @@ export PROJECT_CLONE_URL="<%=projectUrl%>"
 export PROJECT_CLONE_LOCATION="<%=cloneLocation%>"
 export COMMIT_SHA="<%=commitSha%>"
 export PROJECT="<%=name%>"
+export PROJECT_KEY_LOCATION="<%=keyLocation%>"
 
 git_sync() {
-  echo "$PRIVATE_KEY" > /tmp/"$PROJECT"_key.pem
-  chmod 600 /tmp/"$PROJECT"_key.pem
+  echo "$PRIVATE_KEY" > $PROJECT_KEY_LOCATION
+  chmod 600 $PROJECT_KEY_LOCATION
   git config --global credential.helper store
 
-  ssh-agent bash -c "ssh-add /tmp/"$PROJECT"_key.pem; git clone $PROJECT_CLONE_URL $PROJECT_CLONE_LOCATION"
+  ssh-agent bash -c "ssh-add $PROJECT_KEY_LOCATION; git clone $PROJECT_CLONE_URL $PROJECT_CLONE_LOCATION"
 
   echo "----> Pushing Directory $PROJECT_CLONE_LOCATION"
   pushd $PROJECT_CLONE_LOCATION

--- a/job/handlers/resources/macOS_10.12/gitRepo/templates/inStep.sh
+++ b/job/handlers/resources/macOS_10.12/gitRepo/templates/inStep.sh
@@ -23,13 +23,14 @@ export PROJECT_CLONE_URL="<%=projectUrl%>"
 export PROJECT_CLONE_LOCATION="<%=cloneLocation%>"
 export COMMIT_SHA="<%=commitSha%>"
 export PROJECT="<%=name%>"
+export PROJECT_KEY_LOCATION="<%=keyLocation%>"
 
 git_sync() {
-  echo "$PRIVATE_KEY" > /tmp/"$PROJECT"_key.pem
-  chmod 600 /tmp/"$PROJECT"_key.pem
+  echo "$PRIVATE_KEY" > $PROJECT_KEY_LOCATION
+  chmod 600 $PROJECT_KEY_LOCATION
   git config --global credential.helper store
 
-  ssh-agent bash -c "ssh-add /tmp/"$PROJECT"_key.pem; git clone $PROJECT_CLONE_URL $PROJECT_CLONE_LOCATION"
+  ssh-agent bash -c "ssh-add $PROJECT_KEY_LOCATION; git clone $PROJECT_CLONE_URL $PROJECT_CLONE_LOCATION"
 
   echo "----> Pushing Directory $PROJECT_CLONE_LOCATION"
   pushd $PROJECT_CLONE_LOCATION


### PR DESCRIPTION
As far as I can tell, these files are not used at all because we have specific handlers for Github/Github EE, Gitlab, Bitbucket/Bitbucket Server. I'm just copying over the contents just in case it gets used for something. Tested by commenting out the specific handlers.

https://github.com/Shippable/reqProc/issues/336