### PR TITLE
Force TLS 1.2 for GitHub downloads on Windows

### DIFF
--- a/image/x86_64/WindowsServer_2016/Dockerfile
+++ b/image/x86_64/WindowsServer_2016/Dockerfile
@@ -16,6 +16,7 @@ ENV OPENSSH_FIX_USER_FILEPERMS "C:\Program Files\OpenSSH-Win64\FixUserFilePermis
 # execTemplates
 ENV IMAGE_EXEC_TEMPLATES_DIR C:/Users/ContainerAdministrator/Shippable/execTemplates
 RUN mkdir $Env:IMAGE_EXEC_TEMPLATES_DIR; \
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
     Invoke-WebRequest https://github.com/Shippable/execTemplates/archive/{{%TAG%}}.zip -OutFile $env:TEMP\execTemplates.zip; \
     Expand-Archive $env:TEMP\execTemplates.zip -DestinationPath $env:IMAGE_EXEC_TEMPLATES_DIR; \
     Move-Item $env:IMAGE_EXEC_TEMPLATES_DIR\execTemplates-{{%TAG%}}\* -Destination  $env:IMAGE_EXEC_TEMPLATES_DIR; \
@@ -42,7 +43,8 @@ RUN Invoke-WebRequest https://download.docker.com/win/static/stable/x86_64/docke
 RUN choco install -y git
 
 # shipctl
-RUN Invoke-WebRequest https://github.com/Shippable/node/archive/{{%TAG%}}.zip -OutFile $env:TEMP\node.zip; \
+RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+    Invoke-WebRequest https://github.com/Shippable/node/archive/{{%TAG%}}.zip -OutFile $env:TEMP\node.zip; \
     Expand-Archive $env:TEMP\node.zip -DestinationPath $env:TEMP\node; \
     & $env:TEMP\node\node-{{%TAG%}}\shipctl\x86_64\WindowsServer_2016\install.ps1;
 


### PR DESCRIPTION
For #338 

GitHub's recent TLS upgrades causes our downloads to fail because PowerShell still tries TLS 1.0 by default:

```
Invoke-WebRequest : The request was aborted: Could not create SSL/TLS secure channel.
At line:1 char:1
+ Invoke-WebRequest https://github.com/Shippable/execTemplates/archive/ ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (System.Net.HttpWebRequest:HttpWebRequest) [Invoke-WebRequest], WebException
    + FullyQualifiedErrorId : WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand
```

This change forces it to use 1.2 for the current session.