### PR TITLE
Back to Copy-Item -Force to preserve the git directory on Windows

### DIFF
--- a/job/handlers/resources/WindowsServer_2016/gitRepo/templates/providers/_bitbucket.ps1
+++ b/job/handlers/resources/WindowsServer_2016/gitRepo/templates/providers/_bitbucket.ps1
@@ -125,7 +125,7 @@ Function git_sync() {
   popd
 
   echo "----> Copying to $PROJECT_CLONE_LOCATION"
-  Copy-Item "$temp_clone_path\*" -Destination $PROJECT_CLONE_LOCATION -Recurse
+  Copy-Item "$temp_clone_path\*" -Destination $PROJECT_CLONE_LOCATION -Recurse -Force
 
   echo "----> Removing temporary data"
   Remove-Item -Recurse -Force $temp_clone_path

--- a/job/handlers/resources/WindowsServer_2016/gitRepo/templates/providers/_github.ps1
+++ b/job/handlers/resources/WindowsServer_2016/gitRepo/templates/providers/_github.ps1
@@ -118,8 +118,11 @@ Function git_sync() {
 
   popd
 
-  echo "----> Moving to $PROJECT_CLONE_LOCATION"
-  Move-Item "$temp_clone_path" "$PROJECT_CLONE_LOCATION"
+  echo "----> Copying to $PROJECT_CLONE_LOCATION"
+  Copy-Item "$temp_clone_path\*" -Destination $PROJECT_CLONE_LOCATION -Recurse -Force
+
+  echo "----> Removing temporary data"
+  Remove-Item -Recurse -Force $temp_clone_path
 
   exec_exe "ssh-add -D"
 }

--- a/job/handlers/resources/WindowsServer_2016/gitRepo/templates/providers/_gitlab.ps1
+++ b/job/handlers/resources/WindowsServer_2016/gitRepo/templates/providers/_gitlab.ps1
@@ -119,7 +119,7 @@ Function git_sync() {
   popd
 
   echo "----> Copying to $PROJECT_CLONE_LOCATION"
-  Copy-Item "$temp_clone_path\*" -Destination $PROJECT_CLONE_LOCATION -Recurse
+  Copy-Item "$temp_clone_path\*" -Destination $PROJECT_CLONE_LOCATION -Recurse -Force
 
   echo "----> Removing temporary data"
   Remove-Item -Recurse -Force $temp_clone_path


### PR DESCRIPTION
For https://github.com/Shippable/reqProc/issues/338
For https://github.com/Shippable/reqProc/issues/339
For https://github.com/Shippable/reqProc/issues/340

Going back to copy-item because something is preventing move from working. I keep getting access denied, which usually means something is locking the file. Seems like a timing issue, but I didn't want to try adding sleep to fix it.

Addressing multiple issues in one shot because it's the same change and it'll save be 30 minutes on each build.