### PR TITLE
posts new replicate version only if replicateOnPullRequest is set to true in case of pull requests

### DIFF
--- a/workflows/runCI.js
+++ b/workflows/runCI.js
@@ -2331,7 +2331,8 @@ function _postOutResourceVersions(bag, next) {
         dependency.versionDependencyPropertyBag.replicate;
 
       var replicateOnPullRequest = true;
-      if (_.has(dependency.versionDependencyPropertyBag, 'replicateOnPullRequest'))
+      if (_.has(dependency.versionDependencyPropertyBag,
+        'replicateOnPullRequest'))
         replicateOnPullRequest =
           dependency.versionDependencyPropertyBag.replicateOnPullRequest;
 


### PR DESCRIPTION
https://github.com/Shippable/micro/issues/6621

Verified following scenarios:

- If `replicateOnPullRequest` is **set to true** then on pullRequest new versions for replicate resource is getting pushed.

- If `replicateOnPullRequest` is **not available** then on pullRequest new versions for replicate resource is getting pushed.

- If `replicateOnPullRequest` is **set to false** then on pullRequest new versions for replicate resource is **not** getting pushed.
 