### PR TITLE
#380; adds SHIPPABLE_AMI_VERSION.

### DIFF
--- a/_common/micro/setupMS.js
+++ b/_common/micro/setupMS.js
@@ -56,6 +56,7 @@ function setupMS(params) {
   }
 
   global.config.shippableReleaseVersion = process.env.SHIPPABLE_RELEASE_VERSION;
+  global.config.shippableAMIVersion = process.env.SHIPPABLE_AMI_VERSION;
 
   /* Node Type Codes */
   global.nodeTypeCodes = {

--- a/app.js
+++ b/app.js
@@ -81,6 +81,11 @@ if (!global.config.shippableReleaseVersion)
     util.format('%s is missing: shippableReleaseVersion', who)
   );
 
+if (!global.config.shippableAMIVersion)
+  consoleErrors.push(
+    util.format('%s is missing: shippableAMIVersion', who)
+  );
+
 if (!_dirExistsSync(global.config.baseDir))
   consoleErrors.push(util.format('%s is missing directory: %s', who,
     global.config.baseDir));

--- a/workflows/runCI.js
+++ b/workflows/runCI.js
@@ -758,7 +758,8 @@ function _setUpDependencies(bag, next) {
     util.format('JOB_TRIGGERED_BY_NAME=%s',
       bag.inPayload.triggeredByName),
     util.format('JOB_TRIGGERED_BY_ID=%s',
-      bag.inPayload.triggeredById)
+      bag.inPayload.triggeredById),
+    util.format('SHIPPABLE_AMI_VERSION=%s', global.config.shippableAMIVersion)
   ];
   bag.paramEnvs = [];
 


### PR DESCRIPTION
#380 

Makes `SHIPPABLE_AMI_VERSION` an available environment variable in CI.  Tested by updating a custom node in RC.