### PR TITLE
#382; adds SHIPPABLE_AMI_VERSION to runSh.

### DIFF
--- a/job/setupDependencies.js
+++ b/job/setupDependencies.js
@@ -211,6 +211,10 @@ function _setUpDependencies(bag, next) {
     {
       key: 'SHIPPABLE_INTEGRATION_ENVS_PATH',
       value: path.join(bag.buildScriptsDir, 'integration_envs.env')
+    },
+    {
+      key: 'SHIPPABLE_AMI_VERSION',
+      value: global.config.shippableAMIVersion
     }
   ];
   bag.paramEnvs = [];


### PR DESCRIPTION
#382 

Checked that the value is available in a runSh job.