### PR TITLE
Skip SSL verification for git if NODE_TLS_REJECT_UNAUTHORIZED is set …

### DIFF
--- a/job/handlers/resources/CentOS_7/gitRepo/inStep.js
+++ b/job/handlers/resources/CentOS_7/gitRepo/inStep.js
@@ -79,6 +79,8 @@ function _injectDependencies(bag, next) {
   var who = bag.who + '|' + _injectDependencies.name;
   logger.debug(who, 'Inside');
 
+  bag.dependency.noVerifySSL =
+    !_.isUndefined(process.env.NODE_TLS_REJECT_UNAUTHORIZED);
   bag.dependency.privateKey = bag.dependency.propertyBag.sysDeployKey.private;
   bag.dependency.isPrivate =
     bag.dependency.propertyBag.normalizedRepo.isPrivateRepository;

--- a/job/handlers/resources/CentOS_7/gitRepo/templates/providers/_github.sh
+++ b/job/handlers/resources/CentOS_7/gitRepo/templates/providers/_github.sh
@@ -18,6 +18,7 @@ exec_cmd() {
   return $cmd_status
 }
 
+export NO_VERIFY_SSL="<%=noVerifySSL%>"
 export PRIVATE_KEY="<%=privateKey%>"
 export PROJECT_CLONE_URL="<%=projectUrl%>"
 export PROJECT_CLONE_LOCATION="<%=cloneLocation%>"
@@ -30,6 +31,10 @@ export PROJECT="<%=name%>"
 export PROJECT_KEY_LOCATION="<%=keyLocation%>"
 
 git_sync() {
+  if [ "$NO_VERIFY_SSL" == "true" ]; then
+    git config --global http.sslVerify false
+  fi
+
   echo "$PRIVATE_KEY" > $PROJECT_KEY_LOCATION
   chmod 600 $PROJECT_KEY_LOCATION
   git config --global credential.helper store

--- a/job/handlers/resources/CentOS_7/syncRepo/inStep.js
+++ b/job/handlers/resources/CentOS_7/syncRepo/inStep.js
@@ -74,6 +74,8 @@ function _injectDependencies(bag, next) {
   var who = bag.who + '|' + _injectDependencies.name;
   logger.debug(who, 'Inside');
 
+  bag.dependency.noVerifySSL =
+    !_.isUndefined(process.env.NODE_TLS_REJECT_UNAUTHORIZED);
   bag.dependency.privateKey = bag.dependency.propertyBag.sysDeployKey.private;
   bag.dependency.isPrivate =
     bag.dependency.propertyBag.normalizedRepo.isPrivateRepository;

--- a/job/handlers/resources/CentOS_7/syncRepo/templates/providers/_github.sh
+++ b/job/handlers/resources/CentOS_7/syncRepo/templates/providers/_github.sh
@@ -18,6 +18,7 @@ exec_cmd() {
   return $cmd_status
 }
 
+export NO_VERIFY_SSL="<%=noVerifySSL%>"
 export PRIVATE_KEY="<%=privateKey%>"
 export PROJECT_CLONE_URL="<%=projectUrl%>"
 export PROJECT_CLONE_LOCATION="<%=cloneLocation%>"
@@ -27,6 +28,10 @@ export PULL_REQUEST="<%=shaData.pullRequestNumber%>"
 export PULL_REQUEST_BASE_BRANCH="<%=shaData.pullRequestBaseBranch%>"
 
 git_sync() {
+  if [ "$NO_VERIFY_SSL" == "true" ]; then
+    git config --global http.sslVerify false
+  fi
+
   echo "$PRIVATE_KEY" > /tmp/key.pem
 
   chmod 600 /tmp/key.pem

--- a/job/handlers/resources/RHEL_7/gitRepo/inStep.js
+++ b/job/handlers/resources/RHEL_7/gitRepo/inStep.js
@@ -79,6 +79,8 @@ function _injectDependencies(bag, next) {
   var who = bag.who + '|' + _injectDependencies.name;
   logger.debug(who, 'Inside');
 
+  bag.dependency.noVerifySSL =
+    !_.isUndefined(process.env.NODE_TLS_REJECT_UNAUTHORIZED);
   bag.dependency.privateKey = bag.dependency.propertyBag.sysDeployKey.private;
   bag.dependency.isPrivate =
     bag.dependency.propertyBag.normalizedRepo.isPrivateRepository;

--- a/job/handlers/resources/RHEL_7/gitRepo/templates/providers/_github.sh
+++ b/job/handlers/resources/RHEL_7/gitRepo/templates/providers/_github.sh
@@ -18,6 +18,7 @@ exec_cmd() {
   return $cmd_status
 }
 
+export NO_VERIFY_SSL="<%=noVerifySSL%>"
 export PRIVATE_KEY="<%=privateKey%>"
 export PROJECT_CLONE_URL="<%=projectUrl%>"
 export PROJECT_CLONE_LOCATION="<%=cloneLocation%>"
@@ -30,6 +31,10 @@ export PROJECT="<%=name%>"
 export PROJECT_KEY_LOCATION="<%=keyLocation%>"
 
 git_sync() {
+  if [ "$NO_VERIFY_SSL" == "true" ]; then
+    git config --global http.sslVerify false
+  fi
+
   echo "$PRIVATE_KEY" > $PROJECT_KEY_LOCATION
   chmod 600 $PROJECT_KEY_LOCATION
   git config --global credential.helper store

--- a/job/handlers/resources/RHEL_7/syncRepo/inStep.js
+++ b/job/handlers/resources/RHEL_7/syncRepo/inStep.js
@@ -74,6 +74,8 @@ function _injectDependencies(bag, next) {
   var who = bag.who + '|' + _injectDependencies.name;
   logger.debug(who, 'Inside');
 
+  bag.dependency.noVerifySSL =
+    !_.isUndefined(process.env.NODE_TLS_REJECT_UNAUTHORIZED);
   bag.dependency.privateKey = bag.dependency.propertyBag.sysDeployKey.private;
   bag.dependency.isPrivate =
     bag.dependency.propertyBag.normalizedRepo.isPrivateRepository;

--- a/job/handlers/resources/RHEL_7/syncRepo/templates/providers/_github.sh
+++ b/job/handlers/resources/RHEL_7/syncRepo/templates/providers/_github.sh
@@ -18,6 +18,7 @@ exec_cmd() {
   return $cmd_status
 }
 
+export NO_VERIFY_SSL="<%=noVerifySSL%>"
 export PRIVATE_KEY="<%=privateKey%>"
 export PROJECT_CLONE_URL="<%=projectUrl%>"
 export PROJECT_CLONE_LOCATION="<%=cloneLocation%>"
@@ -27,6 +28,10 @@ export PULL_REQUEST="<%=shaData.pullRequestNumber%>"
 export PULL_REQUEST_BASE_BRANCH="<%=shaData.pullRequestBaseBranch%>"
 
 git_sync() {
+  if [ "$NO_VERIFY_SSL" == "true" ]; then
+    git config --global http.sslVerify false
+  fi
+
   echo "$PRIVATE_KEY" > /tmp/key.pem
 
   chmod 600 /tmp/key.pem

--- a/job/handlers/resources/Ubuntu_14.04/gitRepo/inStep.js
+++ b/job/handlers/resources/Ubuntu_14.04/gitRepo/inStep.js
@@ -79,6 +79,8 @@ function _injectDependencies(bag, next) {
   var who = bag.who + '|' + _injectDependencies.name;
   logger.debug(who, 'Inside');
 
+  bag.dependency.noVerifySSL =
+    !_.isUndefined(process.env.NODE_TLS_REJECT_UNAUTHORIZED);
   bag.dependency.privateKey = bag.dependency.propertyBag.sysDeployKey.private;
   bag.dependency.isPrivate =
     bag.dependency.propertyBag.normalizedRepo.isPrivateRepository;

--- a/job/handlers/resources/Ubuntu_14.04/gitRepo/templates/providers/_github.sh
+++ b/job/handlers/resources/Ubuntu_14.04/gitRepo/templates/providers/_github.sh
@@ -18,6 +18,7 @@ exec_cmd() {
   return $cmd_status
 }
 
+export NO_VERIFY_SSL="<%=noVerifySSL%>"
 export PRIVATE_KEY="<%=privateKey%>"
 export PROJECT_CLONE_URL="<%=projectUrl%>"
 export PROJECT_CLONE_LOCATION="<%=cloneLocation%>"
@@ -30,6 +31,10 @@ export PROJECT="<%=name%>"
 export PROJECT_KEY_LOCATION="<%=keyLocation%>"
 
 git_sync() {
+  if [ "$NO_VERIFY_SSL" == "true" ]; then
+    git config --global http.sslVerify false
+  fi
+
   echo "$PRIVATE_KEY" > $PROJECT_KEY_LOCATION
   chmod 600 $PROJECT_KEY_LOCATION
   git config --global credential.helper store

--- a/job/handlers/resources/Ubuntu_14.04/syncRepo/inStep.js
+++ b/job/handlers/resources/Ubuntu_14.04/syncRepo/inStep.js
@@ -74,6 +74,8 @@ function _injectDependencies(bag, next) {
   var who = bag.who + '|' + _injectDependencies.name;
   logger.debug(who, 'Inside');
 
+  bag.dependency.noVerifySSL =
+    !_.isUndefined(process.env.NODE_TLS_REJECT_UNAUTHORIZED);
   bag.dependency.privateKey = bag.dependency.propertyBag.sysDeployKey.private;
   bag.dependency.isPrivate =
     bag.dependency.propertyBag.normalizedRepo.isPrivateRepository;

--- a/job/handlers/resources/Ubuntu_14.04/syncRepo/templates/providers/_github.sh
+++ b/job/handlers/resources/Ubuntu_14.04/syncRepo/templates/providers/_github.sh
@@ -18,6 +18,7 @@ exec_cmd() {
   return $cmd_status
 }
 
+export NO_VERIFY_SSL="<%=noVerifySSL%>"
 export PRIVATE_KEY="<%=privateKey%>"
 export PROJECT_CLONE_URL="<%=projectUrl%>"
 export PROJECT_CLONE_LOCATION="<%=cloneLocation%>"
@@ -27,6 +28,10 @@ export PULL_REQUEST="<%=shaData.pullRequestNumber%>"
 export PULL_REQUEST_BASE_BRANCH="<%=shaData.pullRequestBaseBranch%>"
 
 git_sync() {
+  if [ "$NO_VERIFY_SSL" == "true" ]; then
+    git config --global http.sslVerify false
+  fi
+
   echo "$PRIVATE_KEY" > /tmp/key.pem
 
   chmod 600 /tmp/key.pem

--- a/job/handlers/resources/Ubuntu_16.04/gitRepo/inStep.js
+++ b/job/handlers/resources/Ubuntu_16.04/gitRepo/inStep.js
@@ -79,6 +79,8 @@ function _injectDependencies(bag, next) {
   var who = bag.who + '|' + _injectDependencies.name;
   logger.debug(who, 'Inside');
 
+  bag.dependency.noVerifySSL =
+    !_.isUndefined(process.env.NODE_TLS_REJECT_UNAUTHORIZED);
   bag.dependency.privateKey = bag.dependency.propertyBag.sysDeployKey.private;
   bag.dependency.isPrivate =
     bag.dependency.propertyBag.normalizedRepo.isPrivateRepository;

--- a/job/handlers/resources/Ubuntu_16.04/gitRepo/templates/providers/_github.sh
+++ b/job/handlers/resources/Ubuntu_16.04/gitRepo/templates/providers/_github.sh
@@ -18,6 +18,7 @@ exec_cmd() {
   return $cmd_status
 }
 
+export NO_VERIFY_SSL="<%=noVerifySSL%>"
 export PRIVATE_KEY="<%=privateKey%>"
 export PROJECT_CLONE_URL="<%=projectUrl%>"
 export PROJECT_CLONE_LOCATION="<%=cloneLocation%>"
@@ -30,6 +31,10 @@ export PROJECT="<%=name%>"
 export PROJECT_KEY_LOCATION="<%=keyLocation%>"
 
 git_sync() {
+  if [ "$NO_VERIFY_SSL" == "true" ]; then
+    git config --global http.sslVerify false
+  fi
+
   echo "$PRIVATE_KEY" > $PROJECT_KEY_LOCATION
   chmod 600 $PROJECT_KEY_LOCATION
   git config --global credential.helper store

--- a/job/handlers/resources/Ubuntu_16.04/syncRepo/inStep.js
+++ b/job/handlers/resources/Ubuntu_16.04/syncRepo/inStep.js
@@ -74,6 +74,8 @@ function _injectDependencies(bag, next) {
   var who = bag.who + '|' + _injectDependencies.name;
   logger.debug(who, 'Inside');
 
+  bag.dependency.noVerifySSL =
+    !_.isUndefined(process.env.NODE_TLS_REJECT_UNAUTHORIZED);
   bag.dependency.privateKey = bag.dependency.propertyBag.sysDeployKey.private;
   bag.dependency.isPrivate =
     bag.dependency.propertyBag.normalizedRepo.isPrivateRepository;

--- a/job/handlers/resources/Ubuntu_16.04/syncRepo/templates/providers/_github.sh
+++ b/job/handlers/resources/Ubuntu_16.04/syncRepo/templates/providers/_github.sh
@@ -18,6 +18,7 @@ exec_cmd() {
   return $cmd_status
 }
 
+export NO_VERIFY_SSL="<%=noVerifySSL%>"
 export PRIVATE_KEY="<%=privateKey%>"
 export PROJECT_CLONE_URL="<%=projectUrl%>"
 export PROJECT_CLONE_LOCATION="<%=cloneLocation%>"
@@ -27,6 +28,10 @@ export PULL_REQUEST="<%=shaData.pullRequestNumber%>"
 export PULL_REQUEST_BASE_BRANCH="<%=shaData.pullRequestBaseBranch%>"
 
 git_sync() {
+  if [ "$NO_VERIFY_SSL" == "true" ]; then
+    git config --global http.sslVerify false
+  fi
+
   echo "$PRIVATE_KEY" > /tmp/key.pem
 
   chmod 600 /tmp/key.pem

--- a/runCI/resources/gitRepo/inStep.js
+++ b/runCI/resources/gitRepo/inStep.js
@@ -78,6 +78,8 @@ function _injectDependencies(bag, next) {
   var who = bag.who + '|' + _injectDependencies.name;
   logger.debug(who, 'Inside');
 
+  bag.dependency.noVerifySSL =
+    !_.isUndefined(process.env.NODE_TLS_REJECT_UNAUTHORIZED);
   bag.dependency.privateKey = bag.dependency.propertyBag.sysDeployKey.private;
   bag.dependency.isPrivate =
     bag.dependency.propertyBag.normalizedRepo.isPrivateRepository;

--- a/runCI/resources/gitRepo/templates/providers/_github.sh
+++ b/runCI/resources/gitRepo/templates/providers/_github.sh
@@ -18,6 +18,7 @@ exec_cmd() {
   return $cmd_status
 }
 
+export NO_VERIFY_SSL="<%=noVerifySSL%>"
 export PRIVATE_KEY="<%=privateKey%>"
 export PROJECT_CLONE_URL="<%=projectUrl%>"
 export PROJECT_CLONE_LOCATION="<%=cloneLocation%>"
@@ -28,6 +29,10 @@ export PULL_REQUEST_BASE_BRANCH="<%=shaData.pullRequestBaseBranch%>"
 export PROJECT="<%=name%>"
 
 git_sync() {
+  if [ "$NO_VERIFY_SSL" == "true" ]; then
+    git config --global http.sslVerify false
+  fi
+
   echo "$PRIVATE_KEY" > /tmp/"$PROJECT"_key.pem
   chmod 600 /tmp/"$PROJECT"_key.pem
   git config --global credential.helper store

--- a/runCI/resources/syncRepo/inStep.js
+++ b/runCI/resources/syncRepo/inStep.js
@@ -72,6 +72,8 @@ function _injectDependencies(bag, next) {
   var who = bag.who + '|' + _injectDependencies.name;
   logger.debug(who, 'Inside');
 
+  bag.dependency.noVerifySSL =
+    !_.isUndefined(process.env.NODE_TLS_REJECT_UNAUTHORIZED);
   bag.dependency.privateKey = bag.dependency.propertyBag.sysDeployKey.private;
   bag.dependency.isPrivate =
     bag.dependency.propertyBag.normalizedRepo.isPrivateRepository;

--- a/runCI/resources/syncRepo/templates/providers/_github.sh
+++ b/runCI/resources/syncRepo/templates/providers/_github.sh
@@ -18,6 +18,7 @@ exec_cmd() {
   return $cmd_status
 }
 
+export NO_VERIFY_SSL="<%=noVerifySSL%>"
 export PRIVATE_KEY="<%=privateKey%>"
 export PROJECT_CLONE_URL="<%=projectUrl%>"
 export PROJECT_CLONE_LOCATION="<%=cloneLocation%>"
@@ -27,6 +28,10 @@ export PULL_REQUEST="<%=shaData.pullRequestNumber%>"
 export PULL_REQUEST_BASE_BRANCH="<%=shaData.pullRequestBaseBranch%>"
 
 git_sync() {
+  if [ "$NO_VERIFY_SSL" == "true" ]; then
+    git config --global http.sslVerify false
+  fi
+
   echo "$PRIVATE_KEY" > /tmp/key.pem
 
   chmod 600 /tmp/key.pem


### PR DESCRIPTION
…to true

Verified with only Ubuntu 16.04 so far. This can be set just once when we boot reqProc, but I suppose it is better this way, just in case the scripts get moved out maybe? Not sure.

https://github.com/Shippable/reqProc/issues/407