### PR TITLE
update reqProc to encode state files to base64 and decode from base64

### DIFF
--- a/job/getPreviousState.js
+++ b/job/getPreviousState.js
@@ -113,7 +113,11 @@ function _createFiles(bag, next) {
   async.eachLimit(bag.stateFileJSON, 10,
     function (file, nextFile) {
       var stateFilePath = path.join(bag.previousStateDir, file.path);
-      fs.outputFile(stateFilePath, file.contents,
+      var data = file.contents;
+      var isBase64 = new Buffer(data, 'base64').toString('base64') === data;
+      if (isBase64)
+        data = new Buffer(file.contents, 'base64');
+      fs.outputFile(stateFilePath, data,
         function (err) {
           if (err) {
             var msg = util.format('%s, Failed to save file:%s with err:%s',

--- a/job/handlers/resources/_common/state/inStep.js
+++ b/job/handlers/resources/_common/state/inStep.js
@@ -107,7 +107,11 @@ function _createFiles(bag, next) {
     function (file, nextFile) {
       var outPutFilePath = path.join(bag.buildInDir, bag.dependency.name,
         bag.dependency.type, file.path);
-      fs.outputFile(outPutFilePath, file.contents,
+      var data = file.contents;
+      var isBase64 = new Buffer(data, 'base64').toString('base64') === data;
+      if (isBase64)
+        data = new Buffer(file.contents, 'base64');
+      fs.outputFile(outPutFilePath, data,
         function (err) {
           if (err) {
             var msg = util.format('%s, Failed to create file:%s with err:%s',

--- a/job/handlers/resources/_common/state/outStep.js
+++ b/job/handlers/resources/_common/state/outStep.js
@@ -145,10 +145,12 @@ function _constructJson(bag, next) {
             bag.consoleAdapter.publishMsg(msg);
             return nextFileLocation(true);
           }
+
+          var contents = new Buffer(data).toString('base64');
           var obj = {
             permissions: bag.allFilesPermissions[fileLocation],
             path: path.relative(bag.resourceOutStatePath, fileLocation),
-            contents: data.toString()
+            contents: contents
           };
 
           bag.stateJSON.push(obj);

--- a/job/handlers/saveState.js
+++ b/job/handlers/saveState.js
@@ -140,10 +140,12 @@ function _constructJson(bag, next) {
             bag.consoleAdapter.publishMsg(msg);
             return nextFileLocation(true);
           }
+
+          var contents = new Buffer(data).toString('base64');
           var obj = {
             permissions: bag.allFilesPermissions[fileLocation],
             path: path.relative(bag.stateDir, fileLocation),
-            contents: data.toString()
+            contents: contents
           };
 
           bag.stateJSON.push(obj);

--- a/job/setupDependencies.js
+++ b/job/setupDependencies.js
@@ -1042,7 +1042,11 @@ function __createStateFiles(bag, seriesParams, next) {
   async.eachLimit(bag.outputFileJSON, 10,
     function (file, nextFile) {
       var path = util.format('%s%s', dependencyStatePath, file.path);
-      fs.outputFile(path, file.contents,
+      var data = file.contents;
+      var isBase64 = new Buffer(data, 'base64').toString('base64') === data;
+      if (isBase64)
+        data = new Buffer(file.contents, 'base64');
+      fs.outputFile(path, data,
         function (err) {
           if (err) {
             var msg = util.format('%s, Failed to create file:%s with err:%s',

--- a/runCI/getPreviousState.js
+++ b/runCI/getPreviousState.js
@@ -108,7 +108,11 @@ function _createFiles(bag, next) {
   async.eachLimit(bag.stateFileJSON, 10,
     function (file, nextFile) {
       var stateFilePath = path.join(bag.previousStateDir, file.path);
-      fs.outputFile(stateFilePath, file.contents,
+      var data = file.contents;
+      var isBase64 = new Buffer(data, 'base64').toString('base64') === data;
+      if (isBase64)
+        data = new Buffer(file.contents, 'base64');
+      fs.outputFile(stateFilePath, data,
         function (err) {
           if (err) {
             var msg = util.format('%s, Failed to save file:%s with err:%s',

--- a/runCI/resources/state/inStep.js
+++ b/runCI/resources/state/inStep.js
@@ -107,7 +107,11 @@ function _createFiles(bag, next) {
     function (file, nextFile) {
       var outPutFilePath = path.join(bag.buildInDir, bag.dependency.name,
         bag.dependency.type, file.path);
-      fs.outputFile(outPutFilePath, file.contents,
+      var data = file.contents;
+      var isBase64 = new Buffer(data, 'base64').toString('base64') === data;
+      if (isBase64)
+        data = new Buffer(file.contents, 'base64');
+      fs.outputFile(outPutFilePath, data,
         function (err) {
           if (err) {
             var msg = util.format('%s, Failed to create file:%s with err:%s',

--- a/runCI/resources/state/outStep.js
+++ b/runCI/resources/state/outStep.js
@@ -145,10 +145,11 @@ function _constructJson(bag, next) {
             bag.consoleAdapter.publishMsg(msg);
             return nextFileLocation(true);
           }
+          var contents = new Buffer(data).toString('base64');
           var obj = {
             permissions: bag.allFilesPermissions[fileLocation],
             path: path.relative(bag.resourceOutStatePath, fileLocation),
-            contents: data.toString()
+            contents: contents
           };
 
           bag.stateJSON.push(obj);

--- a/runCI/saveState.js
+++ b/runCI/saveState.js
@@ -137,10 +137,11 @@ function _constructJson(bag, next) {
             bag.consoleAdapter.publishMsg(msg);
             return nextFileLocation(true);
           }
+          var contents = new Buffer(data).toString('base64');
           var obj = {
             permissions: bag.allFilesPermissions[fileLocation],
             path: path.relative(bag.stateDir, fileLocation),
-            contents: data.toString()
+            contents: contents
           };
 
           bag.stateJSON.push(obj);

--- a/workflows/runCI.js
+++ b/workflows/runCI.js
@@ -1565,7 +1565,11 @@ function __createStateFiles(bag, seriesParams, next) {
   async.eachLimit(bag.outputFileJSON, 10,
     function (file, nextFile) {
       var path = util.format('%s%s', dependencyStatePath, file.path);
-      fs.outputFile(path, file.contents,
+      var data = file.contents;
+      var isBase64 = new Buffer(data, 'base64').toString('base64') === data;
+      if (isBase64)
+        data = new Buffer(file.contents, 'base64');
+      fs.outputFile(path, data,
         function (err) {
           if (err) {
             var msg = util.format('%s, Failed to create file:%s with err:%s',


### PR DESCRIPTION
#414

Tests:
1. Tested that previous(the ones which are not base64 encoded) state files are being saved correctly and their content is not base64 decoded.
2. Tested that state files with binary data are being saved and used correctly in IN jobs and their `sha1sum` matches
3. Tested that runCI jobs having IN and OUT to state resource are running fine, where we are updating state resource files.
4. Tested that runSh jobs having IN and OUT to state resource are running fine, where we are updating state resource files
5. Tested that for runSh and runCI jobs, previous state(state files) is being saved correctly
6. Tested that for runSh and runCI IN dependency jobs state is state(files) is being saved correctly


