### PR TITLE
add new line character at the end of grp and cmd typed message for CI consoles

### DIFF
--- a/_common/buildJobConsoleAdapter.js
+++ b/_common/buildJobConsoleAdapter.js
@@ -40,7 +40,7 @@ Adapter.prototype.openGrp = function (consoleGrpName) {
     consoleId: that.consoleGrpId,
     parentConsoleId: 'root',
     type: 'grp',
-    message: that.consoleGrpName,
+    message: that.consoleGrpName + '\n',
     timestamp: that._getTimestamp(),
     isShown: true
   };
@@ -65,7 +65,7 @@ Adapter.prototype.closeGrp = function (isSuccess) {
     consoleId: that.consoleGrpId,
     parentConsoleId: 'root',
     type: 'grp',
-    message: that.consoleGrpName,
+    message: that.consoleGrpName + '\n',
     timestamp: that._getTimestamp(),
     timestampEndedAt: that._getTimestamp(),
     isSuccess: isSuccess,
@@ -94,7 +94,7 @@ Adapter.prototype.openCmd = function (consoleCmdName) {
     consoleId: that.consoleCmdId,
     parentConsoleId: that.consoleGrpId,
     type: 'cmd',
-    message: that.consoleCmdName,
+    message: that.consoleCmdName + '\n',
     timestamp: that._getTimestamp(),
     isShown: true
   };
@@ -117,7 +117,7 @@ Adapter.prototype.closeCmd = function (isSuccess) {
     consoleId: that.consoleCmdId,
     parentConsoleId: that.consoleGrpId,
     type: 'cmd',
-    message: that.consoleCmdName,
+    message: that.consoleCmdName + '\n',
     timestamp: that._getTimestamp(),
     timestampEndedAt: that._getTimestamp(),
     isSuccess: isSuccess,
@@ -138,7 +138,7 @@ Adapter.prototype.publishMsg = function (message) {
     consoleId: uuid.v4(),
     parentConsoleId: that.consoleCmdId,
     type: 'msg',
-    message: message,
+    message: message + '\n',
     timestamp: that._getTimestamp(),
     isShown: true
   };

--- a/_common/jobConsoleAdapter.js
+++ b/_common/jobConsoleAdapter.js
@@ -45,7 +45,7 @@ Adapter.prototype.openGrp = function (consoleGrpName, isShown) {
     consoleId: that.consoleGrpId,
     parentConsoleId: 'root',
     type: 'grp',
-    message: that.consoleGrpName,
+    message: that.consoleGrpName + '\n',
     timestamp: that._getTimestamp(),
     isShown: showGrp
   };
@@ -74,7 +74,7 @@ Adapter.prototype.closeGrp = function (isSuccess, isShown) {
     consoleId: that.consoleGrpId,
     parentConsoleId: 'root',
     type: 'grp',
-    message: that.consoleGrpName,
+    message: that.consoleGrpName + '\n',
     timestamp: that._getTimestamp(),
     timestampEndedAt: that._getTimestamp(),
     isSuccess: isSuccess,
@@ -109,7 +109,7 @@ Adapter.prototype.openCmd = function (consoleCmdName) {
     consoleId: that.consoleCmdId,
     parentConsoleId: that.consoleGrpId,
     type: 'cmd',
-    message: that.consoleCmdName,
+    message: that.consoleCmdName + '\n',
     timestamp: that._getTimestamp(),
     isShown: true
   };
@@ -132,7 +132,7 @@ Adapter.prototype.closeCmd = function (isSuccess) {
     consoleId: that.consoleCmdId,
     parentConsoleId: that.consoleGrpId,
     type: 'cmd',
-    message: that.consoleCmdName,
+    message: that.consoleCmdName + '\n',
     timestamp: that._getTimestamp(),
     timestampEndedAt: that._getTimestamp(),
     isSuccess: isSuccess,
@@ -158,7 +158,7 @@ Adapter.prototype.publishMsg = function (message) {
     consoleId: uuid.v4(),
     parentConsoleId: that.consoleCmdId,
     type: 'msg',
-    message: message,
+    message: message + '\n',
     timestamp: that._getTimestamp(),
     isShown: true
   };

--- a/_common/jobConsoleAdapter.js
+++ b/_common/jobConsoleAdapter.js
@@ -158,7 +158,7 @@ Adapter.prototype.publishMsg = function (message) {
     consoleId: uuid.v4(),
     parentConsoleId: that.consoleCmdId,
     type: 'msg',
-    message: message + '\n',
+    message: message,
     timestamp: that._getTimestamp(),
     isShown: true
   };


### PR DESCRIPTION
https://github.com/Shippable/www/issues/14444

Issue: https://github.com/Shippable/heap/issues/2339
> When I download console logs for runCI jobs, I see that the command and its output are on the same line, without even a space between them:
![40639422-7388cf04-632e-11e8-92f7-2307ea3ceab8](https://user-images.githubusercontent.com/18304961/42149560-5bd6ddde-7df4-11e8-96f3-2b5127354235.png)
Here's the same section for a runSh job that I downloaded:
![40639495-cc2629fe-632e-11e8-901f-8c5179b18b74](https://user-images.githubusercontent.com/18304961/42149576-6eda69b4-7df4-11e8-946a-7b21bfd01619.png)

Verified locally by downloading the CI job logs and buildJob logs., the following change doesn't effect buildJob consoles at all.
CI Job downloaded logs:
[deepikasl-VT1-2.1 (1).log](https://github.com/Shippable/reqProc/files/2196750/deepikasl-VT1-2.1.1.log)

BuildJob consoles logs:
[buildJobConsoles (6).log](https://github.com/Shippable/reqProc/files/2196751/buildJobConsoles.6.log)

