### PR TITLE
add SHIPPABLE_WWW_URL

### DIFF
--- a/job/setupDependencies.js
+++ b/job/setupDependencies.js
@@ -13,6 +13,7 @@ var parseSecureVariable = require('../_common/parseSecureVariable.js');
 function setupDependencies(externalBag, callback) {
   var bag = {
     inPayload: _.clone(externalBag.inPayload),
+    wwwUrl: externalBag.wwwUrl,
     consoleAdapter: externalBag.consoleAdapter,
     builderApiAdapter: externalBag.builderApiAdapter,
     buildJobId: externalBag.buildJobId,
@@ -227,8 +228,18 @@ function _setUpDependencies(bag, next) {
     {
       key: 'SHIPPABLE_AMI_VERSION',
       value: global.config.shippableAMIVersion
+    },
+    {
+      key: 'SHIPPABLE_WWW_URL',
+      value: bag.wwwUrl
+    },
+    {
+      key: 'BUILD_URL',
+      value: util.format('%s/subscriptions/%s/pipelines/builds/%s/consoles',
+        bag.wwwUrl, bag.inPayload.subscriptionId, bag.buildId)
     }
   ];
+
   bag.paramEnvs = [];
 
   if (bag.inPayload.injectedGlobalEnv) {

--- a/workflows/runCI.js
+++ b/workflows/runCI.js
@@ -23,6 +23,7 @@ function runCI(externalBag, callback) {
   var bag = {
     consoleAdapter: externalBag.consoleAdapter,
     rawMessage: externalBag.rawMessage,
+    wwwUrl: externalBag.rawMessage.wwwUrl,
     builderApiAdapter: externalBag.builderApiAdapter,
     nodeId: config.nodeId,
     isSystemNode: config.isSystemNode,
@@ -801,7 +802,8 @@ function _setUpDependencies(bag, next) {
       bag.inPayload.triggeredByName),
     util.format('JOB_TRIGGERED_BY_ID=%s',
       bag.inPayload.triggeredById),
-    util.format('SHIPPABLE_AMI_VERSION=%s', global.config.shippableAMIVersion)
+    util.format('SHIPPABLE_AMI_VERSION=%s', global.config.shippableAMIVersion),
+    util.format('SHIPPABLE_WWW_URL=%s', bag.wwwUrl)
   ];
   bag.paramEnvs = [];
 

--- a/workflows/runSh.js
+++ b/workflows/runSh.js
@@ -38,6 +38,7 @@ function runSh(externalBag, callback) {
     builderApiToken: externalBag.builderApiToken,
     builderApiAdapter: externalBag.builderApiAdapter,
     consoleAdapter: externalBag.consoleAdapter,
+    wwwUrl: externalBag.rawMessage.wwwUrl,
     reqProcDir: global.config.reqProcDir,
     reqKickDir: global.config.reqKickDir,
     reqExecDir: global.config.reqExecDir,


### PR DESCRIPTION
#444
#445

setUpDependencies.js handler is only called in the runSh flow (runCI has its own function and does not use the separate handler) so i did not need to put conditions on the BUILD_URL variable. But i did have to put the WWW_URL in two places so that both jobs and buildJobs will have access to it.

in NF, the pipeline job URL is defined as:
```
 buildUrl: global.systemConfig.wwwUrl + '/subscriptions/' +
      bag.subscription.id + '/pipelines/builds/' + bag.buildJob.buildId +
      '/consoles',
```
so that was also used here. 
