### PR TITLE
#477; allows job inputs without state.

### DIFF
--- a/job/setupDependencies.js
+++ b/job/setupDependencies.js
@@ -1026,12 +1026,12 @@ function __getStateInformation(bag, seriesParams, next) {
 
   bag.consoleAdapter.publishMsg('Getting state information');
 
-  // any job should have this value
+  // any job with state should have this value
   if (!seriesParams.dependency.version.propertyBag.sha) {
     bag.consoleAdapter.publishMsg(util.format(
       '%s is missing propertyBag.sha', seriesParams.dependency.name));
     bag.consoleAdapter.closeCmd(false);
-    return next(true);
+    return next();
   }
   var sha = seriesParams.dependency.version.propertyBag.sha;
 

--- a/workflows/runCI.js
+++ b/workflows/runCI.js
@@ -1591,12 +1591,12 @@ function __getStateInformation(bag, seriesParams, next) {
 
   bag.consoleAdapter.publishMsg('Getting state information');
 
-  // any job should have this value
+  // any job with state should have this value
   if (!seriesParams.dependency.version.propertyBag.sha) {
     bag.consoleAdapter.publishMsg(util.format(
       '%s is missing propertyBag.sha', seriesParams.dependency.name));
     bag.consoleAdapter.closeCmd(false);
-    return next(true);
+    return next();
   }
   var sha = seriesParams.dependency.version.propertyBag.sha;
 


### PR DESCRIPTION
#477 

Logs the error and continues when a job input doesn't have state.  The state files will not be available but the current job will run.