### PR TITLE
#487; adds integration variables following the usual convention for k…

### DIFF
--- a/job/setupDependencies.js
+++ b/job/setupDependencies.js
@@ -983,6 +983,13 @@ function __getDependencyIntegrations(bag, seriesParams, next) {
             value: value,
             surroundWithSingleQuotes: true
           });
+          bag.commonEnvs.push({
+            key: util.format('%s_INTEGRATION_%s',
+              sanitizedDependencyName,
+              key.replace(/[^A-Za-z0-9_]/g, '').toUpperCase()),
+            value: value,
+            surroundWithSingleQuotes: true
+          });
         }
       );
 
@@ -1499,6 +1506,13 @@ function __getDirectIntegrations(bag, seriesParams, next) {
           value  = ___replaceSingleQuotes(value);
           bag.commonEnvs.push({
             key: key,
+            value: value,
+            surroundWithSingleQuotes: true
+          });
+          bag.commonEnvs.push({
+            key: util.format('%s_INTEGRATION_%s',
+              sanitizedIntegrationName,
+              key.replace(/[^A-Za-z0-9_]/g, '').toUpperCase()),
             value: value,
             surroundWithSingleQuotes: true
           });


### PR DESCRIPTION
…eyValuePairs in runSh.

#487 
The same as the current values for escaping and quoting, with the usual name for other integrations.  Confirmed that both variables are present and set.